### PR TITLE
Add labels to kafka_connection_errors metric

### DIFF
--- a/lib/promenade/kafka/connection_subscriber.rb
+++ b/lib/promenade/kafka/connection_subscriber.rb
@@ -39,7 +39,7 @@ module Promenade
         metric(:kafka_connection_request_size).observe(labels, event.payload.fetch(:request_size, 0))
         metric(:kafka_connection_response_size).observe(labels, event.payload.fetch(:response_size, 0))
 
-        metric(:kafka_connection_errors).increment if event.payload.key?(:exception)
+        metric(:kafka_connection_errors).increment(labels) if event.payload.key?(:exception)
       end
     end
   end

--- a/spec/kafka_spec.rb
+++ b/spec/kafka_spec.rb
@@ -299,7 +299,7 @@ RSpec.describe Promenade::Kafka do
         end
 
         it "counts the number of errors" do
-          expect(metric(:kafka_connection_errors).get).to eq 11
+          expect(metric(:kafka_connection_errors).get(labels)).to eq 11
         end
       end
     end


### PR DESCRIPTION
Currently no labels are attached to the kafka_connection_errors metric.

```
# HELP kafka_connection_errors Multiprocess metric
# TYPE kafka_connection_errors counter
kafka_connection_errors 1
```