### PR TITLE
Update prometheus-client-mmap dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     promenade (0.3.0)
       activesupport
-      prometheus-client-mmap (~> 0.9.3)
+      prometheus-client-mmap (~> 0.12.0)
       rack
 
 GEM
@@ -49,7 +49,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
-    prometheus-client-mmap (0.9.10)
+    prometheus-client-mmap (0.12.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -126,4 +126,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.14

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.required_ruby_version = "~> 2.5"
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "prometheus-client-mmap", "~> 0.9.3"
+  spec.add_dependency "prometheus-client-mmap", "~> 0.12.0"
   spec.add_dependency "rack"
 
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.5"
+  spec.required_ruby_version = "> 2.5"
 
   spec.add_dependency "activesupport"
   spec.add_dependency "prometheus-client-mmap", "~> 0.12.0"


### PR DESCRIPTION
prometheus-client-mmap-0.9.10  includes a couple of warnigs

```
~/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/prometheus-client-mmap-0.9.10/lib/prometheus/client/helper/mmaped_file.rb:21: warning: rb_safe_level will be removed in Ruby 3.0
~/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/prometheus-client-mmap-0.9.10/lib/prometheus/client/helper/mmaped_file.rb:21: warning: rb_secure will be removed in Ruby 3.0
```


These have been [fixed](https://gitlab.com/gitlab-org/prometheus-client-mmap/-/merge_requests/53) in later versions of the prometheus-client-mmap gem, but unfortunately, [promenade](https://github.com/errm/promenade) is [stuck on `~> 0.9.3`](https://github.com/errm/promenade/blob/f22c63f9e2d9a2d7307233c56606a281a177738a/promenade.gemspec#L28).

This will eventually prevent any upgrade to ruby 3.0


cc @errm 