### PR TITLE
Relax dependencies prometheus-client-mmap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     promenade (0.2.2)
       activesupport
-      prometheus-client-mmap (~> 0.12.0)
+      prometheus-client-mmap (~> 0)
       rack
 
 GEM
@@ -47,7 +47,7 @@ GEM
     parallel (1.20.1)
     parser (3.0.1.1)
       ast (~> 2.4.1)
-    prometheus-client-mmap (0.12.0)
+    prometheus-client-mmap (0.16.0)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -128,4 +128,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.1.4
+   2.2.32

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.required_ruby_version = ">= 2.5", "< 4"
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "prometheus-client-mmap", "~> 0.12.0"
+  spec.add_dependency "prometheus-client-mmap", "~> 0"
   spec.add_dependency "rack"
 
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
## What

Relax dependencies `prometheus-client-mmap`

## Why

Promenada has missed a couple of minor releases on  `prometheus-client-mmap`  https://gitlab.com/gitlab-org/prometheus-client-mmap/-/blob/master/CHANGELOG.md