### PR TITLE
Add modified Prometheus Rack Client middleware 

### DIFF
--- a/lib/promenade/client/rack/collector.rb
+++ b/lib/promenade/client/rack/collector.rb
@@ -1,0 +1,97 @@
+require "prometheus/client"
+
+module Promenade
+  module Client
+    module Rack
+      # Original code taken from Prometheus Client MMap
+      # https://gitlab.com/gitlab-org/prometheus-client-mmap/-/blob/master/lib/prometheus/client/rack/collector.rb
+      #
+      # Collector is a Rack middleware that provides a sample implementation of
+      # a HTTP tracer. The default label builder can be modified to export a
+      # different set of labels per recorded metric.
+      class Collector
+        attr_reader :app, :registry, :label_builder, :exception_handler
+
+        DEFAULT_LABEL_BUILDER = proc do |env|
+          {
+            method: env["REQUEST_METHOD"].downcase,
+            host:   env["HTTP_HOST"].to_s,
+            path:   env["PATH_INFO"].to_s,
+          }
+        end
+        private_constant :DEFAULT_LABEL_BUILDER
+
+        DEFAULT_EXCEPTION_HANDLER = proc do |exception|
+          @exceptions.increment(exception: exception.class.name)
+        end
+        private_constant :DEFAULT_EXCEPTION_HANDLER
+
+        def initialize(app,
+                       options: {},
+                       label_builder: DEFAULT_LABEL_BUILDER,
+                       exception_handler: DEFAULT_EXCEPTION_HANDLER)
+          @app = app
+          @registry = options[:registry] || ::Prometheus::Client.registry
+          @label_builder = label_builder
+          @exception_handler = exception_handler
+
+          init_request_metrics
+        end
+
+        def call(env) # :nodoc:
+          trace(env) { @app.call(env) }
+        end
+
+        protected
+
+          def init_request_metrics
+            @registry.reset!
+            @requests = @registry.counter(
+              :http_requests_total,
+              "A counter of the total number of HTTP requests made.",
+            )
+            @durations = @registry.summary(
+              :http_request_duration_seconds,
+              "A summary of the response latency.",
+            )
+            @durations_hist = @registry.histogram(
+              :http_req_duration_seconds,
+              "A histogram of the response latency.",
+            )
+          end
+
+          def exceptions
+            @_exceptions ||= @registry.counter(
+              :http_exceptions_total,
+              "A counter of the total number of exceptions raised.",
+            )
+          end
+
+          def trace(env)
+            start = Time.now
+            yield.tap do |response|
+              duration = (Time.now - start).to_f
+              record(labels(env, response), duration)
+            end
+          rescue StandardError => e
+            DEFAULT_EXCEPTION_HANDLER.call(e, exception_handler)
+          end
+
+          def labels(env, response)
+            @label_builder.call(env).tap do |labels|
+              labels[:code] = response.first.to_s
+            end
+          end
+
+          def record(labels, duration)
+            @requests.increment(labels)
+            @durations.observe(labels, duration)
+            @durations_hist.observe(labels, duration)
+
+          rescue StandardError => e
+            DEFAULT_EXCEPTION_HANDLER.call(e, exception_handler)
+          end
+      end
+    end
+  end
+end

--- a/lib/promenade/client/rack/collector.rb
+++ b/lib/promenade/client/rack/collector.rb
@@ -76,6 +76,7 @@ module Promenade
             :requests_counter,
             :exceptions_counter
 
+          # rubocop:disable Rails/TimeZone
           def trace(env)
             start = Time.now
             yield.tap do |response|
@@ -85,6 +86,7 @@ module Promenade
           rescue StandardError => e
             exception_handler.call(e, exceptions_counter)
           end
+          # rubocop:enable Rails/TimeZone
 
           def labels(env, response)
             label_builder.call(env).merge!(code: response.first.to_s)

--- a/spec/promenade/client/rack/collector_spec.rb
+++ b/spec/promenade/client/rack/collector_spec.rb
@@ -146,23 +146,11 @@ RSpec.describe Promenade::Client::Rack::Collector, reset_prometheus_client: true
 
       middleware.call(env)
     end
-
-    xit "calls the custom exception block if provided" do
-      test_handler = double("handler")
-      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
-      app = proc { |_| raise(StandardError, "Status code 500") }
-      exception_handler = proc { |exception| test_double.received_exception(exception.message) }
-      middleware = Promenade::Client::Rack::Collector.new(app)
-
-      expect(test_handler).to receive(:received_exception).with("Status code 500")
-
-      middleware.call(env)
-    end
   end
 
   private
 
     def fetch_metric(metric_name)
-      ::Prometheus::Client.registry.metrics.find { |metric| metric.name == metric_name.to_sym }
+      ::Prometheus::Client.registry.get(metric_name.to_sym)
     end
 end

--- a/spec/promenade/client/rack/collector_spec.rb
+++ b/spec/promenade/client/rack/collector_spec.rb
@@ -1,0 +1,168 @@
+require "spec_helper"
+require "promenade/client/rack/collector"
+require "rack/mock"
+require "support/test_rack_app"
+
+RSpec.describe Promenade::Client::Rack::Collector, reset_prometheus_client: true do
+  describe "#call" do
+    it "preserves the status code" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(status: 418)
+      middleware = Promenade::Client::Rack::Collector.new(app)
+      status, = middleware.call(env)
+
+      expect(status).to eql(418)
+    end
+
+    it "preserves the headers" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(headers: { "HTTP_FIZZ" => "buzz" })
+      middleware = Promenade::Client::Rack::Collector.new(app)
+      _, headers, = middleware.call(env)
+
+      expect(headers).to eql("HTTP_FIZZ" => "buzz")
+    end
+
+    it "preserves the body" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(body: "test-body")
+      middleware = Promenade::Client::Rack::Collector.new(app)
+      _, _, body = middleware.call(env)
+
+      expect(body).to eql("test-body")
+    end
+
+    it "records a histogram for the response time" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new
+      middleware = Promenade::Client::Rack::Collector.new(app)
+
+      histogram = fetch_metric(:http_req_duration_seconds)
+      expect(histogram).to receive(:observe)
+
+      middleware.call(env)
+    end
+
+    it "records a histogram with code, path, host, and method labels" do
+      env = Rack::MockRequest.env_for("/test-path", "HTTP_HOST" => "test.host", method: :post)
+      app = TestRackApp.new(status: 201)
+      middleware = Promenade::Client::Rack::Collector.new(app)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      histogram = fetch_metric(:http_req_duration_seconds)
+      expected_labels = { code: "201", path: "/test-path", host: "test.host", method: "post" }
+      expect(histogram).to receive(:observe).with(expected_labels, expected_duration)
+
+      middleware.call(env)
+    end
+
+    it "records a summary with code, path, host, and method labels" do
+      env = Rack::MockRequest.env_for("/test-path", "HTTP_HOST" => "test.host", method: :post)
+      app = TestRackApp.new(status: 201)
+      middleware = Promenade::Client::Rack::Collector.new(app)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      summary = fetch_metric(:http_request_duration_seconds)
+      expected_labels = { code: "201", path: "/test-path", host: "test.host", method: "post" }
+      expect(summary).to receive(:observe).with(expected_labels, expected_duration)
+
+      middleware.call(env)
+    end
+
+    it "records a counter with code, path, host, and method labels" do
+      env = Rack::MockRequest.env_for("/test-path", "HTTP_HOST" => "test.host", method: :post)
+      app = TestRackApp.new(status: 201)
+      middleware = Promenade::Client::Rack::Collector.new(app)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      counter = fetch_metric(:http_requests_total)
+      expected_labels = { code: "201", path: "/test-path", host: "test.host", method: "post" }
+      expect(counter).to receive(:increment).with(expected_labels)
+
+      middleware.call(env)
+    end
+
+    it "accepts a custom block for Histogram labels" do
+      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
+      app = TestRackApp.new
+      custom_label_builder = proc { |env| { foo: "bar", fizz: env["fizz"] } }
+      middleware = Promenade::Client::Rack::Collector.new(app, label_builder: custom_label_builder)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      histogram = fetch_metric(:http_req_duration_seconds)
+      expected_labels = { foo: "bar", fizz: "buzz", code: "200" }
+      expect(histogram).to receive(:observe).with(expected_labels, expected_duration)
+
+      middleware.call(env)
+    end
+
+    it "accepts a custom block for Summary labels" do
+      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
+      app = TestRackApp.new
+      custom_label_builder = proc { |env| { foo: "bar", fizz: env["fizz"] } }
+      middleware = Promenade::Client::Rack::Collector.new(app, label_builder: custom_label_builder)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      summary = fetch_metric(:http_request_duration_seconds)
+      expected_labels = { foo: "bar", fizz: "buzz", code: "200" }
+      expect(summary).to receive(:observe).with(expected_labels, expected_duration)
+
+      middleware.call(env)
+    end
+
+    it "accepts a custom block for Counter labels" do
+      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
+      app = TestRackApp.new
+      custom_label_builder = proc { |env| { foo: "bar", fizz: env["fizz"] } }
+      middleware = Promenade::Client::Rack::Collector.new(app, label_builder: custom_label_builder)
+
+      expected_duration = 1.0
+      expect_any_instance_of(Time).to receive(:-).and_return(expected_duration)
+
+      counter = fetch_metric(:http_requests_total)
+      expected_labels = { foo: "bar", fizz: "buzz", code: "200" }
+      expect(counter).to receive(:increment).with(expected_labels)
+
+      middleware.call(env)
+    end
+
+    it "increments the exceptions counter if status code is an error" do
+      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
+      app = proc { |env| raise(StandardError, "Status code 500") }
+      middleware = Promenade::Client::Rack::Collector.new(app)
+      counter = fetch_metric(:http_exceptions_total)
+
+      expect(counter).to receive(:increment).with(exception: "StandardError")
+
+      middleware.call(env)
+    end
+
+    xit "calls the custom exception block if provided" do
+      test_handler = double("handler")
+      env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
+      app = proc { |_| raise(StandardError, "Status code 500") }
+      exception_handler = proc { |exception| test_double.received_exception(exception.message) }
+      middleware = Promenade::Client::Rack::Collector.new(app)
+
+      expect(test_handler).to receive(:received_exception).with("Status code 500")
+
+      middleware.call(env)
+    end
+  end
+
+  private
+
+    def fetch_metric(metric_name)
+      ::Prometheus::Client.registry.metrics.find { |metric| metric.name == metric_name.to_sym }
+    end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,15 @@ RSpec.configure do |config|
     allow(Prometheus::Client.configuration).to receive(:value_class).and_return(Prometheus::Client::SimpleValue)
   end
 
+  # Some specs require the same prometheus client between examples, others expect a fresh start.
+  # This allows support for both with the tag :reset_prometheus_client => true
+  config.around(:each, reset_prometheus_client: true) do |example|
+    main_registry = ::Prometheus::Client.registry
+    ::Prometheus::Client.instance_variable_set("@registry", nil)
+    example.run
+    ::Prometheus::Client.instance_variable_set("@registry", main_registry)
+  end
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end

--- a/spec/support/test_rack_app.rb
+++ b/spec/support/test_rack_app.rb
@@ -1,0 +1,13 @@
+class TestRackApp
+  attr_reader :status, :headers, :body
+
+  def initialize(status: 200, headers: {}, body: "It works!")
+    @status = status
+    @headers = headers
+    @body = body
+  end
+
+  def call(env)
+    [status, headers, body]
+  end
+end


### PR DESCRIPTION
# What

Adds the Prometheus Rack Middleware from [prometheus-client-mmap](https://gitlab.com/gitlab-org/prometheus-client-mmap), with some modifications

# Why

This middleware is wrapping around exceptions and counts them separately from the other requests. We want to keep this default behaviour, but make it customisable so that we can handle error requests differently.

# How

Copy the Rack middleware from prometheus-client-mmap, and add an additional configuration block in the initializers.
Refactor the code for better performance and readability.
Wrote custom specs that use a longer-form, but more maintainable writing style.