### PR TITLE
Count exceptions in the main collector block

### DIFF
--- a/lib/promenade/client/rack/collector.rb
+++ b/lib/promenade/client/rack/collector.rb
@@ -73,6 +73,9 @@ module Promenade
           def record(labels, duration)
             requests_counter.increment(labels)
             durations_histogram.observe(labels, duration)
+            if (500..600).include?(labels[:code].to_i)
+              exceptions_counter.increment(exception: "unknown")
+            end
           end
 
           def duration_since(start_time)
@@ -89,6 +92,10 @@ module Promenade
 
           def requests_counter
             registry.get(REQUESTS_COUNTER_NAME)
+          end
+
+          def exceptions_counter
+            registry.get(EXCEPTIONS_COUNTER_NAME)
           end
 
           def register_metrics!

--- a/spec/promenade/client/rack/collector_spec.rb
+++ b/spec/promenade/client/rack/collector_spec.rb
@@ -133,6 +133,17 @@ RSpec.describe Promenade::Client::Rack::Collector, reset_prometheus_client: true
       expect { middleware.call(env) }.to raise_error(StandardError)
     end
 
+    it "increments the exceptions counter if status code is an error but app handles exception" do
+      env = Rack::MockRequest.env_for
+      app = proc { [500, {}, "Error body"] }
+      middleware = Promenade::Client::Rack::Collector.new(app)
+      counter = fetch_metric(:http_exceptions_total)
+
+      expect(counter).to receive(:increment)
+
+      middleware.call(env)
+    end
+
     it "calls the custom exception block if provided" do
       test_handler = double("handler")
       env = Rack::MockRequest.env_for("/", "fizz" => "buzz")


### PR DESCRIPTION
I realised that, because we're inserting the Collector middleware in the middle of the Rails middleware stack, we're not seeing the behaviour we expected to.

`Collector#trace` will successfully return a response, even when the response raised an exception, because of Rails's exception handling—at least this is the case in development.