### PR TITLE
Rack Collector - adding support to accept custom latency buckets

### DIFF
--- a/lib/promenade.rb
+++ b/lib/promenade.rb
@@ -1,5 +1,6 @@
 require "promenade/version"
 require "promenade/setup"
+require "promenade/configuration"
 require "promenade/railtie" if defined? ::Rails::Railtie
 require "promenade/prometheus"
 
@@ -13,6 +14,14 @@ module Promenade
 
     def metric(name)
       Promenade::Prometheus.metric(name)
+    end
+
+    def configuration
+      @_configuration ||= Configuration.new
+    end
+
+    def configure
+      yield(configuration)
     end
   end
 end

--- a/lib/promenade/client/rack/collector.rb
+++ b/lib/promenade/client/rack/collector.rb
@@ -24,8 +24,6 @@ module Promenade
 
         EXCEPTIONS_COUNTER_NAME = :http_exceptions_total
 
-        DEFAULT_LATENCY_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10].freeze
-
         private_constant *%i(
           REQUEST_METHOD
           HTTP_HOST
@@ -38,12 +36,11 @@ module Promenade
         def initialize(app,
                        registry: ::Prometheus::Client.registry,
                        label_builder: RequestLabeler,
-                       latency_buckets: DEFAULT_LATENCY_BUCKETS,
                        exception_handler: nil)
           @app = app
           @registry = registry
           @label_builder = label_builder
-          @latency_buckets = latency_buckets
+          @latency_buckets = Promenade.configuration.rack_latency_buckets
           @exception_handler = exception_handler || default_exception_handler
           register_metrics!
         end

--- a/lib/promenade/configuration.rb
+++ b/lib/promenade/configuration.rb
@@ -1,0 +1,11 @@
+module Promenade
+  class Configuration
+    attr_accessor :rack_latency_buckets
+
+    DEFAULT_RACK_LATENCY_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10].freeze
+
+    def initialize
+      @rack_latency_buckets = DEFAULT_RACK_LATENCY_BUCKETS
+    end
+  end
+end

--- a/spec/promenade/client/rack/collector_spec.rb
+++ b/spec/promenade/client/rack/collector_spec.rb
@@ -146,9 +146,13 @@ RSpec.describe Promenade::Client::Rack::Collector, reset_prometheus_client: true
     end
 
     it "accepts a custom set of histogram buckets" do
+      Promenade.configure do |config|
+        config.rack_latency_buckets = [1.0, 1.5, 2.0]
+      end
+
       env = Rack::MockRequest.env_for
       app = TestRackApp.new
-      middleware = Promenade::Client::Rack::Collector.new(app, latency_buckets: [1.0, 1.5, 2.0])
+      middleware = Promenade::Client::Rack::Collector.new(app)
       expected_labels = { code: "200", controller_action: "unknown#unknown", host: "", method: "get" }
       histogram = fetch_metric(:http_req_duration_seconds)
 

--- a/spec/promenade/client/rack/collector_spec.rb
+++ b/spec/promenade/client/rack/collector_spec.rb
@@ -144,11 +144,31 @@ RSpec.describe Promenade::Client::Rack::Collector, reset_prometheus_client: true
 
       middleware.call(env)
     end
+
+    it "accepts a custom set of histogram buckets" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new
+      middleware = Promenade::Client::Rack::Collector.new(app, latency_buckets: [1.0, 1.5, 2.0])
+      expected_labels = { code: "200", controller_action: "unknown#unknown", host: "", method: "get" }
+      histogram = fetch_metric(:http_req_duration_seconds)
+
+      expect(middleware).to receive(:duration_since).and_return(1.5)
+
+      middleware.call(env)
+
+      normalized_histogram_values = histogram_values_to_h(histogram, expected_labels)
+      expect(normalized_histogram_values).to eq({ 1.0 => 0.0, 1.5 => 1.0, 2.0 => 1.0 })
+    end
   end
 
   private
 
     def fetch_metric(metric_name)
       ::Prometheus::Client.registry.get(metric_name.to_sym)
+    end
+
+    def histogram_values_to_h(histogram, expected_labels)
+      histogram_values = histogram.values[expected_labels]
+      histogram_values.transform_values(&:get)
     end
 end


### PR DESCRIPTION
## What 

Adding support for custom latency buckets

## Why

The default buckets cover a range of latencies from 5 ms to 10 s see,  [Prometheus::Client::Histogram::DEFAULT_BUCKETS](https://gitlab.com/gitlab-org/prometheus-client-mmap/-/blob/master/lib/prometheus/client/histogram.rb#L47-48
), this is intended to capture the typical range of latencies for a web application. However this might not be suitable for your Service-Level Agreements (SLAs) and would be better to have a way to setup a more convenient buckets/[bins](https://en.wikipedia.org/wiki/Histogram#Number_of_bins_and_width)


## How

Developers will have now the option of passing a new variable when including the Rack Collector middleware to their Rack/Rails applications

```ruby
# config/initializers/promenade.rb

Promenade.configure do |config|
  config.rack_latency_buckets = [0.25, 0.350, 0.5, 1, 1.5, 2.5, 5, 10, 15, 19]
end
```

## Anything else

I was not sure about using the `DEFAULT_BUCKETS` already defined in `Prometheus::Client::Histogram::DEFAULT_BUCKETS`, so I've introduced a new constant `Promenade::Configuration::DEFAULT_LATENCY_BUCKETS`
