### PR TITLE
Add support for request queue time metrics

### DIFF
--- a/lib/promenade/client/rack/collector.rb
+++ b/lib/promenade/client/rack/collector.rb
@@ -32,6 +32,7 @@ module Promenade
           HTTP_HOST
           PATH_INFO
           REQUEST_DURATION_HISTOGRAM_NAME
+          REQUEST_QUEUE_TIME_HISTOGRAM_NAME
           REQUESTS_COUNTER_NAME
           EXCEPTIONS_COUNTER_NAME
         )

--- a/lib/promenade/client/rack/http_request_duration_collector.rb
+++ b/lib/promenade/client/rack/http_request_duration_collector.rb
@@ -20,11 +20,9 @@ module Promenade
 
         EXCEPTIONS_COUNTER_NAME = :http_exceptions_total
 
-        private_constant *%i(
-          REQUEST_DURATION_HISTOGRAM_NAME
-          REQUESTS_COUNTER_NAME
-          EXCEPTIONS_COUNTER_NAME
-        )
+        private_constant :REQUEST_DURATION_HISTOGRAM_NAME,
+          :REQUESTS_COUNTER_NAME,
+          :EXCEPTIONS_COUNTER_NAME
 
         def initialize(app,
                        registry: ::Prometheus::Client.registry,

--- a/lib/promenade/client/rack/http_request_duration_collector.rb
+++ b/lib/promenade/client/rack/http_request_duration_collector.rb
@@ -14,12 +14,6 @@ module Promenade
       # a HTTP tracer. The default label builder can be modified to export a
       # different set of labels per recorded metric.
       class HTTPRequestDurationCollector < MiddlwareBase
-        REQUEST_METHOD = "REQUEST_METHOD".freeze
-
-        HTTP_HOST = "HTTP_HOST".freeze
-
-        PATH_INFO = "PATH_INFO".freeze
-
         REQUEST_DURATION_HISTOGRAM_NAME = :http_req_duration_seconds
 
         REQUESTS_COUNTER_NAME = :http_requests_total
@@ -27,9 +21,6 @@ module Promenade
         EXCEPTIONS_COUNTER_NAME = :http_exceptions_total
 
         private_constant *%i(
-          REQUEST_METHOD
-          HTTP_HOST
-          PATH_INFO
           REQUEST_DURATION_HISTOGRAM_NAME
           REQUESTS_COUNTER_NAME
           EXCEPTIONS_COUNTER_NAME

--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -1,0 +1,55 @@
+require "prometheus/client"
+require_relative "middleware_base"
+require_relative "request_labeler"
+require_relative "queue_time_duration"
+
+module Promenade
+  module Client
+    module Rack
+      class HTTPRequestQueueTimeCollector < MiddlwareBase
+        REQUEST_QUEUE_TIME_HISTOGRAM_NAME = :http_req_queue_time_seconds
+
+        private_constant :REQUEST_QUEUE_TIME_HISTOGRAM_NAME
+
+        def initialize(app,
+                       registry: ::Prometheus::Client.registry,
+                       label_builder: RequestLabeler)
+
+          @queue_time_buckets = Promenade.configuration.queue_time_buckets
+
+          super(app, registry: registry, label_builder: label_builder)
+        end
+
+        private
+
+          attr_reader :queue_time_buckets
+
+          def trace(env)
+            start_timestamp = Time.now.utc
+            response = yield
+            record_request_queue_time(labels: labels(env, response),
+              env: env,
+              request_received_time: start_timestamp)
+            response
+          end
+
+          def record_request_queue_time(labels:, env:, request_received_time:)
+            request_queue_duration = QueueTimeDuration.new(env: env,
+              request_received_time: request_received_time)
+            return unless request_queue_duration.valid_header_present?
+
+            queue_time_histogram.observe(labels, request_queue_duration.queue_time_seconds)
+          end
+
+          def register_metrics!
+            registry.histogram(REQUEST_QUEUE_TIME_HISTOGRAM_NAME,
+              "A histogram of request queue time", {}, queue_time_buckets)
+          end
+
+          def queue_time_histogram
+            registry.get(REQUEST_QUEUE_TIME_HISTOGRAM_NAME)
+          end
+      end
+    end
+  end
+end

--- a/lib/promenade/client/rack/middleware_base.rb
+++ b/lib/promenade/client/rack/middleware_base.rb
@@ -1,6 +1,3 @@
-require "prometheus/client"
-require_relative "request_labeler"
-
 module Promenade
   module Client
     module Rack

--- a/lib/promenade/client/rack/middleware_base.rb
+++ b/lib/promenade/client/rack/middleware_base.rb
@@ -1,0 +1,39 @@
+require "prometheus/client"
+require_relative "request_labeler"
+
+module Promenade
+  module Client
+    module Rack
+      class MiddlwareBase
+        def initialize(app, registry:, label_builder:)
+          @app = app
+          @registry = registry
+          @label_builder = label_builder
+
+          register_metrics!
+        end
+
+        def call(env)
+          trace(env) { app.call(env) }
+        end
+
+        private
+
+          attr_reader :app, :label_builder, :registry
+
+          def trace(env)
+            raise NotImplementedError,
+              "Please define #{__method__} in #{self.class}"
+          end
+
+          def labels(env, response)
+            label_builder.call(env).merge!(code: response.first.to_s)
+          end
+
+          def register_metrics!
+            # :noop:
+          end
+      end
+    end
+  end
+end

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -1,0 +1,52 @@
+module Promenade
+  module Client
+    module Rack
+      class QueueTimeDuration
+        REQUEST_START_HEADER = "HTTP_X_REQUEST_START".freeze
+
+        QUEUE_START_HEADER = "HTTP_X_QUEUE_START".freeze
+
+        HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/.freeze
+
+        MILLISECONDS_PER_SECOND = 1_000
+
+        def initialize(env:, request_received_time:)
+          @env = env
+          @request_queued_time_ms = extract_request_queued_time_from_env(env)
+          @valid_header_present = @request_queued_time_ms.is_a?(Float)
+          @request_received_time_ms = request_received_time.utc.to_f
+
+          freeze
+        end
+
+        def valid_header_present?
+          !!@valid_header_present
+        end
+
+        def queue_time_seconds
+          return unless valid_header_present?
+
+          queue_time.round(3)
+        end
+
+        private
+
+          attr_reader :env, :request_queued_time_ms, :request_received_time_ms
+
+          def queue_time
+            request_received_time_ms - request_queued_time_ms
+          end
+
+          def extract_request_queued_time_from_env(env_hash)
+            header_value = env_hash[REQUEST_START_HEADER] || env_hash[QUEUE_START_HEADER]
+            return if header_value.nil?
+
+            header_time_match = header_value.to_s.match(HEADER_VALUE_MATCHER)
+            return unless header_time_match
+
+            header_time_match[:timestamp].to_f
+          end
+      end
+    end
+  end
+end

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -8,7 +8,6 @@ module Promenade
 
         HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/.freeze
 
-
         def initialize(env:, request_received_time:)
           @env = env
           @request_queued_time_ms = extract_request_queued_time_from_env(env)
@@ -19,7 +18,7 @@ module Promenade
         end
 
         def valid_header_present?
-          !!@valid_header_present
+          @valid_header_present
         end
 
         def queue_time_seconds

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -8,7 +8,6 @@ module Promenade
 
         HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/.freeze
 
-        MILLISECONDS_PER_SECOND = 1_000
 
         def initialize(env:, request_received_time:)
           @env = env

--- a/lib/promenade/configuration.rb
+++ b/lib/promenade/configuration.rb
@@ -1,11 +1,15 @@
 module Promenade
   class Configuration
-    attr_accessor :rack_latency_buckets
+    attr_accessor :queue_time_buckets, :rack_latency_buckets
 
     DEFAULT_RACK_LATENCY_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10].freeze
 
+    # 2ms to 20ms in intervals of 2ms
+    DEFAULT_QUEUE_TIME_BUCKETS = [0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.016, 0.018, 0.02].freeze
+
     def initialize
       @rack_latency_buckets = DEFAULT_RACK_LATENCY_BUCKETS
+      @queue_time_buckets = DEFAULT_QUEUE_TIME_BUCKETS
     end
   end
 end

--- a/lib/promenade/configuration.rb
+++ b/lib/promenade/configuration.rb
@@ -4,8 +4,7 @@ module Promenade
 
     DEFAULT_RACK_LATENCY_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10].freeze
 
-    # 2ms to 20ms in intervals of 2ms
-    DEFAULT_QUEUE_TIME_BUCKETS = [0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.016, 0.018, 0.02].freeze
+    DEFAULT_QUEUE_TIME_BUCKETS = [0.01, 0.5, 1.0, 10.0, 30.0].freeze
 
     def initialize
       @rack_latency_buckets = DEFAULT_RACK_LATENCY_BUCKETS

--- a/lib/promenade/railtie.rb
+++ b/lib/promenade/railtie.rb
@@ -1,13 +1,16 @@
 require "promenade/setup"
 require "promenade/engine"
-require "promenade/client/rack/collector"
+require "promenade/client/rack/http_request_duration_collector"
+require "promenade/client/rack/http_request_queue_time_collector"
 
 module Promenade
   class Railtie < ::Rails::Railtie
     initializer "promenade.configure_rails_initialization" do
       Promenade.setup
       Rails.application.config.middleware.insert_after ActionDispatch::ShowExceptions,
-        Promenade::Client::Rack::Collector
+        Promenade::Client::Rack::HTTPRequestDurationCollector
+      Rails.application.config.middleware.insert_after ActionDispatch::ShowExceptions,
+        Promenade::Client::Rack::HTTPRequestQueueTimeCollector
     end
   end
 end

--- a/lib/promenade/railtie.rb
+++ b/lib/promenade/railtie.rb
@@ -9,7 +9,7 @@ module Promenade
       Promenade.setup
       Rails.application.config.middleware.insert_after ActionDispatch::ShowExceptions,
         Promenade::Client::Rack::HTTPRequestDurationCollector
-      Rails.application.config.middleware.insert_after ActionDispatch::ShowExceptions,
+      Rails.application.config.middleware.insert 0,
         Promenade::Client::Rack::HTTPRequestQueueTimeCollector
     end
   end

--- a/spec/integration/exception_handling_spec.rb
+++ b/spec/integration/exception_handling_spec.rb
@@ -11,8 +11,11 @@ RSpec.describe "Prometheus request tracking middleware", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     get "/success"
   end
@@ -27,8 +30,11 @@ RSpec.describe "Prometheus request tracking middleware", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     expect { get "/server-error" }.to raise_error(StandardError)
   end
@@ -43,8 +49,11 @@ RSpec.describe "Prometheus request tracking middleware", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     get "/client-error"
   end
@@ -59,8 +68,11 @@ RSpec.describe "Prometheus request tracking middleware", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     expect { get "/not-found" }.to raise_error(ActionController::RoutingError)
   end
@@ -75,8 +87,11 @@ RSpec.describe "Prometheus request tracking middleware", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     expect { get "/404" }.to raise_error(ActionController::RoutingError)
   end

--- a/spec/integration/queue_time_recording_spec.rb
+++ b/spec/integration/queue_time_recording_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+require "active_support/testing/time_helpers"
+require "active_support/core_ext/numeric/time"
+require "active_support/duration"
+
+require "support/queue_time_header_helpers"
+
+RSpec.describe "Queue time recording", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+  include QueueTimeHeaderHelpers
+
+  it "records the queue time if X-Request-start header is present" do
+    freeze_time
+    start_time = Time.now.utc - 0.01
+
+    histogram = ::Prometheus::Client.registry.get(:http_req_queue_time_seconds)
+    expected_queue_time = 0.01
+    expected_labels = {
+      code: "200",
+      controller_action: "test_responses#success",
+      host: "www.example.com",
+      method: "get",
+    }
+
+    expect(histogram).to receive(:observe).with(expected_labels, expected_queue_time)
+
+    get "/success", headers: { "x-request-start" => request_start_timestamp(start_time) }
+  end
+
+  it "records the queue time if X-Queue-start header is present" do
+    freeze_time
+    start_time = Time.now.utc - 0.01
+
+    histogram = ::Prometheus::Client.registry.get(:http_req_queue_time_seconds)
+    expected_queue_time = 0.01
+    expected_labels = {
+      code: "200",
+      controller_action: "test_responses#success",
+      host: "www.example.com",
+      method: "get",
+    }
+
+    expect(histogram).to receive(:observe).with(expected_labels, expected_queue_time)
+
+    get "/success", headers: { "x-queue-start" => request_start_timestamp(start_time) }
+  end
+
+  it "doesn't attempt to record if no header is present" do
+    freeze_time
+    histogram = ::Prometheus::Client.registry.get(:http_req_queue_time_seconds)
+
+    expect(histogram).not_to receive(:observe)
+
+    get "/success", headers: {}
+  end
+
+  it "doesn't attempt to record if header is not valid format" do
+    freeze_time
+    start_time = Time.now.utc - 0.01
+    histogram = ::Prometheus::Client.registry.get(:http_req_queue_time_seconds)
+
+    expect(histogram).to_not receive(:observe)
+
+    get "/success", headers: { "x-request-start" => start_time.to_s }
+  end
+end

--- a/spec/integration/show_exceptions_middleware_spec.rb
+++ b/spec/integration/show_exceptions_middleware_spec.rb
@@ -18,8 +18,11 @@ RSpec.describe "Show exceptions integration", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     get "/bad-request"
 
@@ -37,8 +40,11 @@ RSpec.describe "Show exceptions integration", type: :request do
       method: "get",
     }
 
-    expect_any_instance_of(Promenade::Client::Rack::Collector).to receive(:current_time).and_return(1.0, 2.0)
-    expect(histogram).to receive(:observe).with(expected_labels, response_duration)
+    expect_any_instance_of(
+      Promenade::Client::Rack::HTTPRequestDurationCollector,
+    ).to receive(:current_time).and_return(1.0, 2.0)
+    expect(histogram).to receive(:observe).
+      with(expected_labels, response_duration)
 
     get "/server-error"
 

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
         request_received_time: Time.now.utc,
       )
 
-
       expect(duration.valid_header_present?).to be(false)
     end
 

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+require "promenade/client/rack/queue_time_duration"
+require "active_support/testing/time_helpers"
+require "support/queue_time_header_helpers"
+
+RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
+  include ActiveSupport::Testing::TimeHelpers
+  include QueueTimeHeaderHelpers
+
+  describe "#valid_header_present?" do
+    it "returns false when no queue header present" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: {},
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.valid_header_present?).to be(false)
+    end
+
+    it "returns false when queue header is Timestamp format" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => Time.now.utc.to_s },
+        request_received_time: Time.now.utc,
+      )
+
+
+      expect(duration.valid_header_present?).to be(false)
+    end
+
+    it "returns false when queue header is an invalid Integer" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => 1234 },
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.valid_header_present?).to be(false)
+    end
+
+    it "returns true when queue header is present and a valid value" do
+      freeze_time
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => request_start_timestamp },
+        request_received_time: Time.now.utc,
+      )
+      travel_to Time.now.utc + 2 do
+        expect(duration.valid_header_present?).to be(true)
+      end
+    end
+  end
+
+  describe "#queue_time_seconds" do
+    it "prioritises HTTP_X_REQUEST_START before HTTP_X_QUEUE_START" do
+      env = {}
+      freeze_time
+      travel_to(Time.now.utc - 10) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
+      travel_to(Time.now.utc - 5) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
+      travel_to(Time.now.utc)
+
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: env,
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to eql(10.0)
+
+      # Perform same expectation as above, but with the values flipped. This way
+      # we can ensure we're testing the priority of the headers
+      travel_to(Time.now.utc - 10) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
+      travel_to(Time.now.utc - 5) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
+      travel_to(Time.now.utc)
+
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: env,
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to eql(5.0)
+    end
+
+    it "returns nil when neither HTTP_X_REQUEST_START nor HTTP_X_QUEUE_START is present" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: {},
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to be(nil)
+    end
+
+    it "returns nil when the header is present but has no 't=' prefix" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => Time.now.to_f.to_s },
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to be(nil)
+    end
+
+    it "returns nil when the header is present but has invalid timestamp" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => Time.now.to_i.to_s[0..-2] },
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to be(nil)
+    end
+
+    it "returns the difference between queue time and received time when valid" do
+      freeze_time
+      env = Hash.new
+
+      travel_to(Time.now.utc - 10) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
+      travel_to(Time.now.utc)
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: env,
+        request_received_time: Time.now.utc,
+      )
+
+      expect(duration.queue_time_seconds).to eq(10.0)
+    end
+  end
+end

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
 
     it "returns nil when the header is present but has invalid timestamp" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: { "HTTP_X_REQUEST_START" => Time.now.to_i.to_s[0..-2] },
+        env: { "HTTP_X_REQUEST_START" => "invalid-value" },
         request_received_time: Time.now.utc,
       )
 

--- a/spec/support/queue_time_header_helpers.rb
+++ b/spec/support/queue_time_header_helpers.rb
@@ -1,0 +1,7 @@
+module QueueTimeHeaderHelpers
+  private
+
+    def request_start_timestamp(time_obj = Time.now.utc)
+      "t=#{time_obj.to_f.round(3)}"
+    end
+end


### PR DESCRIPTION
## What

Adds Prometheus metrics to track request queue time.

## Why

We want to gain a deeper insight into our real request latency, and so we need to track queue time in addition to the request processing time.

## How

Extend the collector middleware to check for the existence of either a `X-REQUEST-START` header or a `X-QUEUE-START` header. If either of these is present and has a valid value, pluck the value and subtract it from the current timestamp.

The computed duration value is then collected in a Prometheus histogram.
