### PR TITLE
Replace described_class with class name

### DIFF
--- a/spec/promenade/client/rack/http_request_duration_collector_spec.rb
+++ b/spec/promenade/client/rack/http_request_duration_collector_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
     it "preserves the status code" do
       env = Rack::MockRequest.env_for
       app = TestRackApp.new(status: 418)
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
       status, = middleware.call(env)
 
       expect(status).to eql(418)
@@ -17,7 +17,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
     it "preserves the headers" do
       env = Rack::MockRequest.env_for
       app = TestRackApp.new(headers: { "HTTP_FIZZ" => "buzz" })
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
       _, headers, = middleware.call(env)
 
       expect(headers).to eql("HTTP_FIZZ" => "buzz")
@@ -26,7 +26,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
     it "preserves the body" do
       env = Rack::MockRequest.env_for
       app = TestRackApp.new(body: "test-body")
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
       _, _, body = middleware.call(env)
 
       expect(body).to eql("test-body")
@@ -35,7 +35,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
     it "records a histogram for the response time" do
       env = Rack::MockRequest.env_for
       app = TestRackApp.new
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
 
       histogram = fetch_metric(:http_req_duration_seconds)
       expect(histogram).to receive(:observe)
@@ -52,7 +52,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
         },
         method: :post)
       app = TestRackApp.new(status: 201)
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
 
       expected_duration = 1.0
       histogram = fetch_metric(:http_req_duration_seconds)
@@ -78,7 +78,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
         },
         method: :post)
       app = TestRackApp.new(status: 201)
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
 
       counter = fetch_metric(:http_requests_total)
       expected_labels = {
@@ -97,7 +97,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
       env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
       app = TestRackApp.new
       custom_label_builder = proc { |_env| { foo: "bar", fizz: _env["fizz"] } }
-      middleware = described_class.new(app, label_builder: custom_label_builder)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app, label_builder: custom_label_builder)
 
       expected_duration = 1.0
       histogram = fetch_metric(:http_req_duration_seconds)
@@ -113,7 +113,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
       env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
       app = TestRackApp.new
       custom_label_builder = proc { |_env| { foo: "bar", fizz: _env["fizz"] } }
-      middleware = described_class.new(app, label_builder: custom_label_builder)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app, label_builder: custom_label_builder)
       counter = fetch_metric(:http_requests_total)
       expected_labels = { foo: "bar", fizz: "buzz", code: "200" }
 
@@ -125,7 +125,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
     it "increments the exceptions counter if status code is an error" do
       env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
       app = proc { raise(StandardError, "Status code 500") }
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
       counter = fetch_metric(:http_exceptions_total)
 
       expect(counter).to receive(:increment).with(exception: "StandardError")
@@ -138,7 +138,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
       env = Rack::MockRequest.env_for("/", "fizz" => "buzz")
       app = proc { |_| raise(StandardError, "Status code 500") }
       exception_handler = proc { |exception| test_handler.received_exception(exception.message) }
-      middleware = described_class.new(app, exception_handler: exception_handler)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app, exception_handler: exception_handler)
 
       expect(test_handler).to receive(:received_exception).with("Status code 500")
 
@@ -152,7 +152,7 @@ RSpec.describe Promenade::Client::Rack::HTTPRequestDurationCollector, reset_prom
 
       env = Rack::MockRequest.env_for
       app = TestRackApp.new
-      middleware = described_class.new(app)
+      middleware = Promenade::Client::Rack::HTTPRequestDurationCollector.new(app)
       expected_labels = { code: "200", controller_action: "unknown#unknown", host: "", method: "get" }
       histogram = fetch_metric(:http_req_duration_seconds)
 

--- a/spec/promenade/client/rack/request_labeler_spec.rb
+++ b/spec/promenade/client/rack/request_labeler_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         },
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(controller_action: "test-controller#test-action")
     end
@@ -20,7 +20,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         "HTTP_HOST" => "test-host",
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(host: "test-host")
     end
@@ -29,7 +29,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         "REQUEST_METHOD" => "test-method",
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(method: "test-method")
     end
@@ -38,7 +38,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         "REQUEST_METHOD" => "TEST-METHOD",
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(method: "test-method")
     end
@@ -50,7 +50,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         },
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(controller_action: "unknown#test-action")
     end
@@ -61,7 +61,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         },
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(controller_action: "test-controller#unknown")
     end
@@ -70,7 +70,7 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
         "action_dispatch.request.parameters" => Hash.new,
       }
 
-      labels = described_class.call(env_hash)
+      labels = Promenade::Client::Rack::RequestLabeler.call(env_hash)
 
       expect(labels).to include(controller_action: "unknown#unknown")
     end

--- a/spec/promenade_spec.rb
+++ b/spec/promenade_spec.rb
@@ -6,63 +6,63 @@ RSpec.describe Promenade do
   describe "defining and using a counter" do
     describe "defaults" do
       before do
-        described_class.counter :promenade_testing_counter do
+        Promenade.counter :promenade_testing_counter do
           doc "a docstring"
         end
       end
 
       it "can be incremented" do
-        described_class.metric(:promenade_testing_counter).increment
-        expect(described_class.metric(:promenade_testing_counter).get).to eq 1
+        Promenade.metric(:promenade_testing_counter).increment
+        expect(Promenade.metric(:promenade_testing_counter).get).to eq 1
 
-        10.times { described_class.metric(:promenade_testing_counter).increment }
-        expect(described_class.metric(:promenade_testing_counter).get).to eq 11
+        10.times { Promenade.metric(:promenade_testing_counter).increment }
+        expect(Promenade.metric(:promenade_testing_counter).get).to eq 11
 
-        described_class.metric(:promenade_testing_counter).increment({}, 9)
-        expect(described_class.metric(:promenade_testing_counter).get).to eq 20
+        Promenade.metric(:promenade_testing_counter).increment({}, 9)
+        expect(Promenade.metric(:promenade_testing_counter).get).to eq 20
       end
 
       it "accepts labels" do
-        described_class.metric(:promenade_testing_counter).increment({ nice: "label" }, 3)
-        expect(described_class.metric(:promenade_testing_counter).get(nice: "label")).to eq 3
+        Promenade.metric(:promenade_testing_counter).increment({ nice: "label" }, 3)
+        expect(Promenade.metric(:promenade_testing_counter).get(nice: "label")).to eq 3
       end
 
       it "can be incremented from the class" do
-        described_class.metric(:promenade_testing_counter).increment
+        Promenade.metric(:promenade_testing_counter).increment
 
-        expect(described_class.metric(:promenade_testing_counter).get).to eq 1
+        expect(Promenade.metric(:promenade_testing_counter).get).to eq 1
       end
 
       it "doesn't throw an error when trying to redefine a counter" do
         expect do
-          described_class.counter :promenade_testing_counter
+          Promenade.counter :promenade_testing_counter
         end.to_not raise_error
       end
 
       it "throws an error when trying a metric that isn't defined" do
-        expect { described_class.metric(:not_a_counter) }.to raise_error "No metric defined for: not_a_counter, you must define a metric before using it"
+        expect { Promenade.metric(:not_a_counter) }.to raise_error "No metric defined for: not_a_counter, you must define a metric before using it"
       end
     end
 
     describe "setting some options" do
       before do
-        described_class.counter :promenade_testing_counter do
+        Promenade.counter :promenade_testing_counter do
           doc "a docstring"
           base_labels foo: "bar"
         end
       end
 
       it "uses the base_labels" do
-        described_class.metric(:promenade_testing_counter).increment
-        expect(described_class.metric(:promenade_testing_counter).get(foo: "bar")).to eq 1
+        Promenade.metric(:promenade_testing_counter).increment
+        expect(Promenade.metric(:promenade_testing_counter).get(foo: "bar")).to eq 1
       end
 
       it "accepts other labels" do
-        described_class.metric(:promenade_testing_counter).increment
-        described_class.metric(:promenade_testing_counter).increment({ foo: "baz" }, 7)
+        Promenade.metric(:promenade_testing_counter).increment
+        Promenade.metric(:promenade_testing_counter).increment({ foo: "baz" }, 7)
 
-        expect(described_class.metric(:promenade_testing_counter).get).to eq 1
-        expect(described_class.metric(:promenade_testing_counter).get(foo: "baz")).to eq 7
+        expect(Promenade.metric(:promenade_testing_counter).get).to eq 1
+        expect(Promenade.metric(:promenade_testing_counter).get(foo: "baz")).to eq 7
       end
     end
   end
@@ -70,38 +70,38 @@ RSpec.describe Promenade do
   describe "defining and using a gauge" do
     context "defaults" do
       before do
-        described_class.gauge :promenade_testing_gauge do
+        Promenade.gauge :promenade_testing_gauge do
           doc "This is a gauge to use in the tests"
         end
       end
 
       it "can be set" do
-        described_class.metric(:promenade_testing_gauge).set({}, 7)
-        expect(described_class.metric(:promenade_testing_gauge).get).to eq 7
+        Promenade.metric(:promenade_testing_gauge).set({}, 7)
+        expect(Promenade.metric(:promenade_testing_gauge).get).to eq 7
 
-        described_class.metric(:promenade_testing_gauge).set({}, 11)
-        expect(described_class.metric(:promenade_testing_gauge).get).to eq 11
+        Promenade.metric(:promenade_testing_gauge).set({}, 11)
+        expect(Promenade.metric(:promenade_testing_gauge).get).to eq 11
       end
 
       it "can be set from the class" do
-        described_class.metric(:promenade_testing_gauge).set({}, 21)
-        expect(described_class.metric(:promenade_testing_gauge).get).to eq 21
+        Promenade.metric(:promenade_testing_gauge).set({}, 21)
+        expect(Promenade.metric(:promenade_testing_gauge).get).to eq 21
       end
 
       it "does not throw an error when trying to redefine a gauge" do
         expect do
-          described_class.gauge :promenade_testing_gauge
+          Promenade.gauge :promenade_testing_gauge
         end.to_not raise_error
       end
 
       it "has a multiprocess mode of all" do
-        expect(described_class.metric(:promenade_testing_gauge).instance_variable_get(:@multiprocess_mode)).to eq :all
+        expect(Promenade.metric(:promenade_testing_gauge).instance_variable_get(:@multiprocess_mode)).to eq :all
       end
     end
 
     context "setting some options" do
       before do
-        described_class.gauge :promenade_testing_gauge do
+        Promenade.gauge :promenade_testing_gauge do
           doc "some other docstring"
           multiprocess_mode :liveall
           base_labels base: "isbelongtous"
@@ -109,15 +109,15 @@ RSpec.describe Promenade do
       end
 
       it "sets the multiprocess mode" do
-        expect(described_class.metric(:promenade_testing_gauge).instance_variable_get(:@multiprocess_mode)).to eq :liveall
+        expect(Promenade.metric(:promenade_testing_gauge).instance_variable_get(:@multiprocess_mode)).to eq :liveall
       end
 
       it "sets the base_labels" do
-        expect(described_class.metric(:promenade_testing_gauge).base_labels).to eq(base: "isbelongtous")
+        expect(Promenade.metric(:promenade_testing_gauge).base_labels).to eq(base: "isbelongtous")
       end
 
       it "sets the docstring" do
-        expect(described_class.metric(:promenade_testing_gauge).docstring).to eq "some other docstring"
+        expect(Promenade.metric(:promenade_testing_gauge).docstring).to eq "some other docstring"
       end
     end
   end
@@ -125,45 +125,45 @@ RSpec.describe Promenade do
   describe "defining and using a summary" do
     context "defaults" do
       before do
-        described_class.summary :promenade_testing_summary do
+        Promenade.summary :promenade_testing_summary do
           doc "This is a summary to use in the tests"
         end
       end
 
       it "can observe" do
-        described_class.metric(:promenade_testing_summary).observe({}, 7)
-        expect(described_class.metric(:promenade_testing_summary).get).to eq 7.0
+        Promenade.metric(:promenade_testing_summary).observe({}, 7)
+        expect(Promenade.metric(:promenade_testing_summary).get).to eq 7.0
 
-        described_class.metric(:promenade_testing_summary).observe({}, 11)
-        expect(described_class.metric(:promenade_testing_summary).get).to eq 18.0
+        Promenade.metric(:promenade_testing_summary).observe({}, 11)
+        expect(Promenade.metric(:promenade_testing_summary).get).to eq 18.0
       end
 
       it "can observe from the class" do
-        described_class.metric(:promenade_testing_summary).observe({}, 21)
-        expect(described_class.metric(:promenade_testing_summary).get).to eq 21
+        Promenade.metric(:promenade_testing_summary).observe({}, 21)
+        expect(Promenade.metric(:promenade_testing_summary).get).to eq 21
       end
 
       it "does not throw an error when trying to redefine a summary" do
         expect do
-          described_class.gauge :promenade_testing_summary
+          Promenade.gauge :promenade_testing_summary
         end.to_not raise_error
       end
     end
 
     context "setting some options" do
       before do
-        described_class.summary :promenade_testing_summary do
+        Promenade.summary :promenade_testing_summary do
           doc "some other docstring"
           base_labels all_your_base: "isbelongtous"
         end
       end
 
       it "sets the base_labels" do
-        expect(described_class.metric(:promenade_testing_summary).base_labels).to eq(all_your_base: "isbelongtous")
+        expect(Promenade.metric(:promenade_testing_summary).base_labels).to eq(all_your_base: "isbelongtous")
       end
 
       it "sets the docstring" do
-        expect(described_class.metric(:promenade_testing_summary).docstring).to eq "some other docstring"
+        expect(Promenade.metric(:promenade_testing_summary).docstring).to eq "some other docstring"
       end
     end
   end
@@ -171,14 +171,14 @@ RSpec.describe Promenade do
   describe "defining and using a histogram" do
     context "defaults" do
       before do
-        described_class.histogram :promenade_testing_histogram do
+        Promenade.histogram :promenade_testing_histogram do
           doc "This is a histogram to use in the tests"
         end
       end
 
       it "can observe" do
-        described_class.metric(:promenade_testing_histogram).observe({}, 0.5)
-        expect(described_class.metric(:promenade_testing_histogram).get).to eq(
+        Promenade.metric(:promenade_testing_histogram).observe({}, 0.5)
+        expect(Promenade.metric(:promenade_testing_histogram).get).to eq(
           0.005 => 0.0,
           0.01 => 0.0,
           0.025 => 0.0,
@@ -196,15 +196,15 @@ RSpec.describe Promenade do
 
     context "custom buckets" do
       before do
-        described_class.histogram :promenade_testing_histogram do
+        Promenade.histogram :promenade_testing_histogram do
           doc "This is a histogram to use in the tests"
           buckets [0.25, 0.5, 1.0]
         end
       end
 
       it "can observe" do
-        described_class.metric(:promenade_testing_histogram).observe({}, 0.5)
-        expect(described_class.metric(:promenade_testing_histogram).get).to eq(
+        Promenade.metric(:promenade_testing_histogram).observe({}, 0.5)
+        expect(Promenade.metric(:promenade_testing_histogram).get).to eq(
           0.25 => 0.0,
           0.5 => 1.0,
           1.0 => 1.0,
@@ -214,15 +214,15 @@ RSpec.describe Promenade do
 
     context "bucket preset" do
       before do
-        described_class.histogram :promenade_testing_histogram do
+        Promenade.histogram :promenade_testing_histogram do
           doc "This is a histogram to use in the tests"
           buckets :network
         end
       end
 
       it "can observe" do
-        described_class.metric(:promenade_testing_histogram).observe({}, 0.5)
-        expect(described_class.metric(:promenade_testing_histogram).get).to eq(
+        Promenade.metric(:promenade_testing_histogram).observe({}, 0.5)
+        expect(Promenade.metric(:promenade_testing_histogram).get).to eq(
           0.005 => 0.0,
           0.01 => 0.0,
           0.025 => 0.0,
@@ -241,7 +241,7 @@ RSpec.describe Promenade do
     context "invalid bucket preset" do
       it "throws an error" do
         expect do
-          described_class.histogram :promenade_testing_oven_temperature do
+          Promenade.histogram :promenade_testing_oven_temperature do
             doc "Temperature of the oven in degrees science (Celsius)"
             buckets :gas_oven
           end


### PR DESCRIPTION
## What

Replace instances of `described_class` with the specific class name.

## Why

To bring the code more in-line with the [Cookpad RSpec style guide](https://github.com/cookpad/global-style-guides/tree/main/rspec).

## How

Global find + replace :sweat_smile:
