### PR TITLE
Remove controller_action from queue time metrics

### DIFF
--- a/lib/promenade/client/rack/exception_handler.rb
+++ b/lib/promenade/client/rack/exception_handler.rb
@@ -1,6 +1,6 @@
 require "action_dispatch/middleware/exception_wrapper"
 require_relative "singleton_caller"
-require_relative "request_labeler"
+require_relative "request_controller_action_labeler"
 
 module Promenade
   module Client
@@ -17,7 +17,7 @@ module Promenade
         end
 
         def call(exception, env_hash, duration)
-          labels = RequestLabeler.call(env_hash)
+          labels = RequestControllerActionLabeler.call(env_hash)
           labels.merge!(code: status_code_for_exception(exception))
 
           histogram.observe(labels, duration.to_f)

--- a/lib/promenade/client/rack/http_request_duration_collector.rb
+++ b/lib/promenade/client/rack/http_request_duration_collector.rb
@@ -1,6 +1,6 @@
 require "prometheus/client"
 require_relative "middleware_base"
-require_relative "request_labeler"
+require_relative "request_controller_action_labeler"
 require_relative "exception_handler"
 require_relative "queue_time_duration"
 
@@ -17,7 +17,7 @@ module Promenade
 
         def initialize(app,
                        registry: ::Prometheus::Client.registry,
-                       label_builder: RequestLabeler,
+                       label_builder: RequestControllerActionLabeler,
                        exception_handler: nil)
 
           @latency_buckets = Promenade.configuration.rack_latency_buckets

--- a/lib/promenade/client/rack/request_controller_action_labeler.rb
+++ b/lib/promenade/client/rack/request_controller_action_labeler.rb
@@ -1,0 +1,42 @@
+require_relative "request_labeler"
+module Promenade
+  module Client
+    module Rack
+      class RequestControllerActionLabeler < RequestLabeler
+        PARAMS_KEY = "action_dispatch.request.parameters".freeze
+
+        PATH_PARAMS_KEY = "action_dispatch.request.path_parameters".freeze
+
+        CONTROLLER = "controller".freeze
+
+        ACTION = "action".freeze
+
+        UNKNOWN = "unknown".freeze
+
+        SEPARATOR = "#".freeze
+
+        private_constant :PARAMS_KEY, :CONTROLLER, :ACTION, :UNKNOWN, :SEPARATOR
+
+        def call(env)
+          super.merge({
+            controller_action: controller_action_from_env(env),
+          })
+        end
+
+        private
+
+          def controller_action_from_env(env)
+            controller = env.dig(PARAMS_KEY, CONTROLLER) ||
+                         env.dig(PATH_PARAMS_KEY, CONTROLLER.to_sym) ||
+                         UNKNOWN
+
+            action = env.dig(PARAMS_KEY, ACTION) ||
+                     env.dig(PATH_PARAMS_KEY, ACTION.to_sym) ||
+                     UNKNOWN
+
+            [controller, action].join(SEPARATOR)
+          end
+      end
+    end
+  end
+end

--- a/lib/promenade/client/rack/request_labeler.rb
+++ b/lib/promenade/client/rack/request_labeler.rb
@@ -9,41 +9,14 @@ module Promenade
 
         HTTP_HOST = "HTTP_HOST".freeze
 
-        PARAMS_KEY = "action_dispatch.request.parameters".freeze
-
-        PATH_PARAMS_KEY = "action_dispatch.request.path_parameters".freeze
-
-        CONTROLLER = "controller".freeze
-
-        ACTION = "action".freeze
-
-        UNKNOWN = "unknown".freeze
-
-        SEPARATOR = "#".freeze
-
-        private_constant :REQUEST_METHOD, :HTTP_HOST, :PARAMS_KEY, :CONTROLLER, :ACTION, :UNKNOWN, :SEPARATOR
+        private_constant :REQUEST_METHOD, :HTTP_HOST
 
         def call(env)
           {
             method: env[REQUEST_METHOD].to_s.downcase,
             host: env[HTTP_HOST].to_s,
-            controller_action: controller_action_from_env(env),
           }
         end
-
-        private
-
-          def controller_action_from_env(env)
-            controller = env.dig(PARAMS_KEY, CONTROLLER) ||
-                         env.dig(PATH_PARAMS_KEY, CONTROLLER.to_sym) ||
-                         UNKNOWN
-
-            action = env.dig(PARAMS_KEY, ACTION) ||
-                     env.dig(PATH_PARAMS_KEY, ACTION.to_sym) ||
-                     UNKNOWN
-
-            [controller, action].join(SEPARATOR)
-          end
       end
     end
   end

--- a/spec/integration/queue_time_recording_spec.rb
+++ b/spec/integration/queue_time_recording_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe "Queue time recording", type: :request do
     expected_queue_time = 0.01
     expected_labels = {
       code: "200",
-      controller_action: "test_responses#success",
       host: "www.example.com",
       method: "get",
     }
@@ -35,7 +34,6 @@ RSpec.describe "Queue time recording", type: :request do
     expected_queue_time = 0.01
     expected_labels = {
       code: "200",
-      controller_action: "test_responses#success",
       host: "www.example.com",
       method: "get",
     }

--- a/spec/promenade/client/rack/request_controller_action_labeler_spec.rb
+++ b/spec/promenade/client/rack/request_controller_action_labeler_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require "promenade/client/rack/request_labeler"
+require "promenade/client/rack/request_controller_action_labeler"
 
-RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client: true do
+RSpec.describe Promenade::Client::Rack::RequestControllerActionLabeler, reset_prometheus_client: true do
   describe "#call" do
     it "sets the controller_action from action_dispatch.request.parameters" do
       env_hash = {

--- a/spec/promenade/client/rack/request_labeler_spec.rb
+++ b/spec/promenade/client/rack/request_labeler_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+require "promenade/client/rack/request_labeler"
+
+RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client: true do
+  describe "#call" do
+    it "sets the host from env HTTP_HOST" do
+      env_hash = {
+        "HTTP_HOST" => "test-host",
+      }
+
+      labels = described_class.call(env_hash)
+
+      expect(labels).to include(host: "test-host")
+    end
+
+    it "sets the method from env REQUEST_METHOD" do
+      env_hash = {
+        "REQUEST_METHOD" => "test-method",
+      }
+
+      labels = described_class.call(env_hash)
+
+      expect(labels).to include(method: "test-method")
+    end
+
+    it "converts the method to lower-case string" do
+      env_hash = {
+        "REQUEST_METHOD" => "TEST-METHOD",
+      }
+
+      labels = described_class.call(env_hash)
+
+      expect(labels).to include(method: "test-method")
+    end
+  end
+end


### PR DESCRIPTION
## What

Remove controller_action from request queue time metrics

## Why

We decided this information was irrelevant for application queue time, and so better to remove and reduce the size of time series data we collect.

## How

I split the label builder class up, extracting the controller action labels into a subclass. I then applied this subclass to the request-duration middleware to preserve behaviour there, and removed the expectation for queue time middleware to collect controller-action.
