### PR TITLE
Code review suggestions for Add Karafka monitoring 

### DIFF
--- a/lib/promenade/karafka/statistics_subscriber.rb
+++ b/lib/promenade/karafka/statistics_subscriber.rb
@@ -58,8 +58,7 @@ module Promenade
 
         def report_connection_metrics(brokers, client_id)
           labels = {
-            client: client_id,
-            api: "",
+            client: client_id
           }
 
           brokers.map do |broker_name, broker_values|

--- a/lib/promenade/karafka/statistics_subscriber.rb
+++ b/lib/promenade/karafka/statistics_subscriber.rb
@@ -58,7 +58,8 @@ module Promenade
 
         def report_connection_metrics(brokers, client_id)
           labels = {
-            client: client_id
+            client: client_id,
+            api: "",
           }
 
           brokers.map do |broker_name, broker_values|

--- a/spec/karafka_spec.rb
+++ b/spec/karafka_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Promenade::Karafka do
       end
 
       it "exposes the kafka connection latency" do
-        expect(Promenade.metric(:kafka_connection_latency).get(labels)).to eq(
+        expect(Promenade.metric(:kafka_connection_latency_seconds).get(labels)).to eq(
           0.005 => 11.0,
           0.01 => 11.0,
           0.025 => 11.0,

--- a/spec/karafka_spec.rb
+++ b/spec/karafka_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Promenade::Karafka do
 
     describe "reports connection_metrics" do
       let(:labels) do
-        { client: client_id, api: "", broker: "localhost:9092/2" }
+        { client: client_id, broker: "localhost:9092/2" }
       end
 
       it "exposes the kafka connection calls" do

--- a/spec/karafka_spec.rb
+++ b/spec/karafka_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Promenade::Karafka do
 
     describe "reports connection_metrics" do
       let(:labels) do
-        { client: client_id, broker: "localhost:9092/2" }
+        { client: client_id, api: "", broker: "localhost:9092/2" }
       end
 
       it "exposes the kafka connection calls" do


### PR DESCRIPTION
## What

Code Review suggestions for https://github.com/errm/promenade/pull/40

1. Use seconds instead of milliseconds or microseconds according to [this](https://github.com/errm/promenade/pull/40/files#r1127727312) discussion, 
2. following the Prometheus guideline I've added the unit suffix to `kafka_connection_latency` metric
~~3. Api level is not used, so we can remove this label~~