### PR TITLE
Fix: Update prometheus-client-mmap dependency version and add Ruby 3.3 to the test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     promenade (0.11.0)
       actionpack
       activesupport (> 6.0, < 8.0)
-      prometheus-client-mmap (~> 1.0)
+      prometheus-client-mmap (~> 0.28)
       rack
 
 GEM
@@ -123,7 +123,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    prometheus-client-mmap (1.0.2)
+    prometheus-client-mmap (0.28.1)
       rb_sys (~> 0.9)
     racc (1.7.1)
     rack (2.2.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     promenade (0.11.0)
       actionpack
       activesupport (> 6.0, < 8.0)
-      prometheus-client-mmap (~> 0.16.0)
+      prometheus-client-mmap (~> 1.0)
       rack
 
 GEM
@@ -123,7 +123,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    prometheus-client-mmap (0.16.2)
+    prometheus-client-mmap (1.0.2)
+      rb_sys (~> 0.9)
     racc (1.7.1)
     rack (2.2.7)
     rack-test (2.1.0)
@@ -158,6 +159,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    rb_sys (0.9.84)
     regexp_parser (2.8.1)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack"
   spec.add_dependency "activesupport", "> 6.0", "< 8.0"
-  spec.add_dependency "prometheus-client-mmap", "~> 0.16.0"
+  spec.add_dependency "prometheus-client-mmap", "~> 1.0"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack"
   spec.add_dependency "activesupport", "> 6.0", "< 8.0"
-  spec.add_dependency "prometheus-client-mmap", "~> 1.0"
+  spec.add_dependency "prometheus-client-mmap", "~> 0.28"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Happy Holidays 🎄 🎉 

Fixes #49

Edit: I bumped to v1.x but found out that since 1.0, [it requires Rust](https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap/-/blob/master/CHANGELOG.md?ref_type=heads), so I downgraded to 0.28, which is known to work with Ruby 3.3. I think that the update to v1 and Rust requirement is your call to make