### PR TITLE
Update prometheus-client-mmap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     promenade (0.12.0)
       actionpack
       activesupport (> 6.0, < 8.0)
-      prometheus-client-mmap (~> 0.28)
+      prometheus-client-mmap (~> 1.1)
       rack
 
 GEM
@@ -123,8 +123,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    prometheus-client-mmap (0.28.1)
-      rb_sys (~> 0.9)
+    prometheus-client-mmap (1.1.0)
+      rb_sys (~> 0.9.86)
     racc (1.7.1)
     rack (2.2.7)
     rack-test (2.1.0)
@@ -159,7 +159,7 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
-    rb_sys (0.9.84)
+    rb_sys (0.9.87)
     regexp_parser (2.8.1)
     rexml (3.2.5)
     rspec (3.12.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
-    prometheus-client-mmap (1.1.0)
+    prometheus-client-mmap (1.1.1)
       rb_sys (~> 0.9.86)
     racc (1.7.1)
     rack (2.2.7)

--- a/promenade.gemspec
+++ b/promenade.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack"
   spec.add_dependency "activesupport", "> 6.0", "< 8.0"
-  spec.add_dependency "prometheus-client-mmap", "~> 0.28"
+  spec.add_dependency "prometheus-client-mmap", "~> 1.1"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Following up on the previous PR, I'm bumping the `prometheus-client-mmap` dep, once again, looks better now with the inclusion of the precompiled gem.