### PR TITLE
Add middleware to record YJIT code_region_size

### DIFF
--- a/lib/promenade.rb
+++ b/lib/promenade.rb
@@ -1,7 +1,6 @@
 require "promenade/version"
 require "promenade/setup"
 require "promenade/configuration"
-require "promenade/railtie" if defined? Rails::Railtie
 require "promenade/prometheus"
 
 module Promenade
@@ -25,3 +24,5 @@ module Promenade
     end
   end
 end
+
+require "promenade/railtie" if defined? Rails::Railtie

--- a/lib/promenade/railtie.rb
+++ b/lib/promenade/railtie.rb
@@ -2,11 +2,13 @@ require "promenade/setup"
 require "promenade/engine"
 require "promenade/client/rack/http_request_duration_collector"
 require "promenade/client/rack/http_request_queue_time_collector"
+require "promenade/yjit/middleware"
 
 module Promenade
   class Railtie < ::Rails::Railtie
     initializer "promenade.configure_rails_initialization" do
       Promenade.setup
+      Rails.application.config.middleware.use Promenade::YJIT::Middlware if defined? ::RubyVM::YJIT
       Rails.application.config.middleware.insert_after ActionDispatch::ShowExceptions,
         Promenade::Client::Rack::HTTPRequestDurationCollector
       Rails.application.config.middleware.insert 0,

--- a/lib/promenade/yjit/middleware.rb
+++ b/lib/promenade/yjit/middleware.rb
@@ -1,0 +1,22 @@
+require "promenade/yjit/stats"
+
+module Promenade
+  module YJIT
+    class Middlware
+      RACK_AFTER_REPLY = "rack.after_reply".freeze
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if env.key?(RACK_AFTER_REPLY)
+          env[RACK_AFTER_REPLY] << -> {
+            ::Promenade::YJIT::Stats.instrument
+          }
+        end
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/promenade/yjit/stats.rb
+++ b/lib/promenade/yjit/stats.rb
@@ -6,7 +6,7 @@ module Promenade
       end
 
       def self.instrument
-        return unless defined? ::RubyVM::YJIT
+        return unless defined?(::RubyVM::YJIT) && ::RubyVM::YJIT.enabled?
 
         Promenade.metric(:ruby_yjit_code_region_size).set({}, ::RubyVM::YJIT.runtime_stats[:code_region_size])
       end

--- a/lib/promenade/yjit/stats.rb
+++ b/lib/promenade/yjit/stats.rb
@@ -1,0 +1,15 @@
+module Promenade
+  module YJIT
+    class Stats
+      Promenade.gauge :ruby_yjit_code_region_size do
+        doc "Ruby YJIT code size"
+      end
+
+      def self.instrument
+        return unless defined? ::RubyVM::YJIT
+
+        Promenade.metric(:ruby_yjit_code_region_size).set({}, ::RubyVM::YJIT.runtime_stats[:code_region_size])
+      end
+    end
+  end
+end

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Promenade::YJIT::Stats do
       # This method should not blow up in any case
       expect { described_class.instrument }.not_to raise_error
 
-      if defined? RubyVM::YJIT && defined? RubyVM::YJIT.enable
+      if defined?(RubyVM::YJIT) && defined?(RubyVM::YJIT.enable)
 
         # We want to test that this doesn't blow up when yjit is present but isn't enabled yet
         # you need to run the testsuite with yjit disabled for this to work

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -1,0 +1,13 @@
+require "promenade/yjit/stats"
+
+RSpec.describe Promenade::YJIT::Stats do
+  describe "recording yjit stats" do
+    it "records code_region_size" do
+      if defined? RubyVM::YJIT
+        described_class.instrument
+
+        expect(Promenade.metric(:ruby_yjit_code_region_size).get).to eq RubyVM::YJIT.runtime_stats[:code_region_size]
+      end
+    end
+  end
+end

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -3,9 +3,12 @@ require "promenade/yjit/stats"
 RSpec.describe Promenade::YJIT::Stats do
   describe "recording yjit stats" do
     it "records code_region_size" do
-      if defined? RubyVM::YJIT
+      # This method should not blow up in any case
+      expect { described_class.instrument }.not_to raise_error
 
-        # We want to test that this doesn't blow up when yjit isn't enabled
+      if defined? RubyVM::YJIT && defined? RubyVM::YJIT.enable
+
+        # We want to test that this doesn't blow up when yjit is present but isn't enabled yet
         # you need to run the testsuite with yjit disabled for this to work
         expect(RubyVM::YJIT.enabled?).to be_falsey
         expect { described_class.instrument }.not_to raise_error

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe Promenade::YJIT::Stats do
         described_class.instrument
 
         expect(Promenade.metric(:ruby_yjit_code_region_size).get).to eq RubyVM::YJIT.runtime_stats[:code_region_size]
+      else
+        version = RUBY_VERSION.match(/(\d).(\d).\d/)
+        major = version[1].to_i
+        minor = version[2].to_i
+        if major >= 3 && minor >= 3
+          flunk "YJIT must be avalibe to test properly in ruby 3.3+"
+        end
       end
     end
   end

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -4,6 +4,14 @@ RSpec.describe Promenade::YJIT::Stats do
   describe "recording yjit stats" do
     it "records code_region_size" do
       if defined? RubyVM::YJIT
+
+        # We want to test that this doesn't blow up when yjit isn't enabled
+        # you need to run the testsuite with yjit disabled for this to work
+        expect(RubyVM::YJIT.enabled?).to be_falsey
+        expect { described_class.instrument }.not_to raise_error
+
+        # Then we enable yjit to test the instrumentation
+        RubyVM::YJIT.enable
         described_class.instrument
 
         expect(Promenade.metric(:ruby_yjit_code_region_size).get).to eq RubyVM::YJIT.runtime_stats[:code_region_size]


### PR DESCRIPTION
* We are using the rack.after_reply hook for this to not impact response times - https://github.blog/2022-04-11-performance-at-github-deferring-stats-with-rack-after_reply/
* Just a simple implimentation now, so we can optimise --yjit-exec-mem-size on applications, but this should be simple to extend to record the other metrics exposed by runtime_stats if they are needed.