### PR TITLE
Implement workaround for Pitchfork PID provider compatibility

### DIFF
--- a/lib/promenade/pitchfork/worker_pid_provider.rb
+++ b/lib/promenade/pitchfork/worker_pid_provider.rb
@@ -2,11 +2,7 @@ module Promenade
   module Pitchfork
     class WorkerPidProvider
       def self.fetch
-        if wid = worker_id
-          wid
-        else
-          "process_id_#{Process.pid}"
-        end
+        worker_id || "process_id_#{Process.pid}"
       end
 
       def self.object_based_worker_id
@@ -24,9 +20,9 @@ module Promenade
       end
 
       def self.worker_id
-        if matchdata = program_name.match(/pitchfork.*worker\[(.+)\]/)
+        if matchdata = program_name.match(/pitchfork.*worker\[(.+)\]/) # rubocop:disable Lint/AssignmentInCondition
           "pitchfork_#{matchdata[1]}"
-        elsif object_worker_id = object_based_worker_id
+        elsif object_worker_id = object_based_worker_id # rubocop:disable Lint/AssignmentInCondition
           "pitchfork_#{object_worker_id}"
         end
       end

--- a/lib/promenade/pitchfork/worker_pid_provider.rb
+++ b/lib/promenade/pitchfork/worker_pid_provider.rb
@@ -1,0 +1,35 @@
+module Promenade
+  module Pitchfork
+    class WorkerPidProvider
+      def self.fetch
+        if wid = worker_id
+          wid
+        else
+          "process_id_#{Process.pid}"
+        end
+      end
+
+      def self.object_based_worker_id
+        return unless defined?(::Pitchfork::Worker)
+
+        workers = ObjectSpace.each_object(::Pitchfork::Worker)
+        return if workers.nil?
+
+        workers_first = workers.first
+        workers_first&.nr
+      end
+
+      def self.program_name
+        $PROGRAM_NAME
+      end
+
+      def self.worker_id
+        if matchdata = program_name.match(/pitchfork.*worker\[(.+)\]/)
+          "pitchfork_#{matchdata[1]}"
+        elsif object_worker_id = object_based_worker_id
+          "pitchfork_#{object_worker_id}"
+        end
+      end
+    end
+  end
+end

--- a/lib/promenade/setup.rb
+++ b/lib/promenade/setup.rb
@@ -19,7 +19,7 @@ module Promenade
     ENV.fetch("PROMETHEUS_MULTIPROC_DIR", root_dir.join("tmp", "promenade"))
   end
 
-  def setup
+  def setup # rubocop:disable Metrics/AbcSize
     unless File.directory? multiprocess_files_dir
       FileUtils.mkdir_p multiprocess_files_dir
     end

--- a/lib/promenade/setup.rb
+++ b/lib/promenade/setup.rb
@@ -36,7 +36,7 @@ module Promenade
       # Instead, we define a method that dynamically loads the appropriate PID provider based on the active server.
       # As a fallback, we use the process ID.
 
-      if defined?(Unicorn)
+      if defined?(::Unicorn)
         require "prometheus/client/support/unicorn"
         pid_provider_method = ::Prometheus::Client::Support::Unicorn.method(:worker_pid_provider)
       elsif defined?(::Pitchfork)

--- a/spec/promenade/pitchfork/worker_pid_provider_spec.rb
+++ b/spec/promenade/pitchfork/worker_pid_provider_spec.rb
@@ -1,0 +1,66 @@
+require "spec_helper"
+require "promenade/pitchfork/worker_pid_provider"
+
+RSpec.describe Promenade::Pitchfork::WorkerPidProvider do
+  describe ".fetch" do
+    subject { described_class.fetch }
+
+    context "when worker_id is defined" do
+      let(:worker_id) { "worker_id" }
+
+      before do
+        allow(described_class).to receive(:worker_id).and_return(worker_id)
+      end
+
+      it { is_expected.to eq(worker_id) }
+    end
+
+    context "when worker_id is not defined" do
+      before do
+        allow(described_class).to receive(:worker_id).and_return(nil)
+        allow(Process).to receive(:pid).and_return(123)
+      end
+
+      it { is_expected.to eq("process_id_123") }
+    end
+  end
+
+  describe ".worker_id" do
+    subject { described_class.send(:worker_id) }
+    before do
+      allow(described_class).to receive(:program_name).and_return(program_name)
+    end
+
+    context "when program_name matches pitchfork worker" do
+      let(:program_name) { "pitchfork (gen:0) worker[1] - requests: 13, waiting" }
+
+
+      it { is_expected.to eq("pitchfork_1") }
+
+      context "when program_name matches pitchfork worker" do
+        let(:program_name) { "pitchfork worker[1]" }
+
+        it { is_expected.to eq("pitchfork_1") }
+      end
+    end
+  end
+
+  describe ".object_based_worker_id" do
+    subject { described_class.send(:object_based_worker_id) }
+
+    context "when Pitchfork::Worker is defined" do
+      let(:worker) { double("Pitchfork::Worker", nr: 1) }
+
+      before do
+        stub_const("Pitchfork::Worker", Class.new)
+        allow(ObjectSpace).to receive(:each_object).with(Pitchfork::Worker).and_return([worker])
+      end
+
+      it { is_expected.to eq(1) }
+    end
+
+    context "when Pitchfork::Worker is not defined" do
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/setup_spec.rb
+++ b/spec/setup_spec.rb
@@ -2,6 +2,33 @@ require "tmpdir"
 
 RSpec.describe Promenade do
   describe ".setup" do
+    context "pid_provider" do
+      before do
+        stub_const(self.class.description, true)
+      end
+
+      context "Unicorn" do
+        it "uses the unicorn pid provider" do
+          Promenade.setup
+          expect(Prometheus::Client.configuration.pid_provider.to_s).to match "Prometheus::Client::Support::Unicorn"
+        end
+      end
+
+      context "Pitchfork" do
+        it "uses the pitchfork pid provider" do
+          Promenade.setup
+          expect(Prometheus::Client.configuration.pid_provider.to_s).to match "Promenade::Pitchfork::WorkerPidProvider"
+        end
+      end
+
+      context "Puma" do
+        it "uses the puma pid provider" do
+          Promenade.setup
+          expect(Prometheus::Client.configuration.pid_provider.to_s).to match "Prometheus::Client::Support::Puma"
+        end
+      end
+    end
+
     context "without rails" do
       context "environment variable set" do
         let(:multiproc_root) { Pathname.new(Dir.mktmpdir) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require "simplecov"
 SimpleCov.minimum_coverage 99
-SimpleCov.start
+SimpleCov.start do
+  add_filter "/spec/"
+end
 
 if ENV["CI"]
   require "simplecov-cobertura"

--- a/spec/yjit_spec.rb
+++ b/spec/yjit_spec.rb
@@ -1,4 +1,5 @@
 require "promenade/yjit/stats"
+require "promenade/yjit/middleware"
 require "open3"
 
 RSpec.describe Promenade::YJIT::Stats do
@@ -54,5 +55,19 @@ RSpec.describe Promenade::YJIT::Stats do
     Integer(string)
   rescue StandardError
     string.to_f
+  end
+end
+
+RSpec.describe Promenade::YJIT::Middlware do
+  let(:app) { double(:app, call: nil) }
+
+  it "is adds it's instrumentation method to the rack.after_reply array" do
+    stats = class_spy("Promenade::YJIT::Stats").as_stubbed_const
+
+    after_reply = []
+    described_class.new(app).call({ "rack.after_reply" => after_reply })
+    after_reply.each(&:call)
+
+    expect(stats).to have_received(:instrument)
   end
 end


### PR DESCRIPTION
## What

This PR provides a workaround for using the same PID provider with Unicorn, Pitchfork, and Puma servers. Since these servers are not loaded simultaneously, we cannot use a unified method directly. To address this, a new method has been defined to dynamically load the appropriate PID provider based on the running server. This approach is inspired by [Prometheus Client mmap - Unicorn Support](https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap/-/blob/master/lib/prometheus/client/support/unicorn.rb?ref_type=heads). See [Prometheus Client mmap - PID Cardinality](https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap#pid-cardinality) for reference.


## How

Introduced a method to conditionally load the PID provider based on whether Unicorn, Pitchfork, or Puma is active. This streamlines PID provider management by employing a unified approach for all three servers. Additionally, a fallback PID provider has been implemented to address situations where none of the specified servers are detected.