### PR TITLE
Support Unicorn in Promenade::Raindrops::Middleware

### DIFF
--- a/lib/promenade/railtie.rb
+++ b/lib/promenade/railtie.rb
@@ -14,7 +14,7 @@ module Promenade
       Rails.application.config.middleware.insert 0,
         Promenade::Client::Rack::HTTPRequestQueueTimeCollector
 
-      if defined?(::Raindrops)
+      if defined?(::Raindrops) && (defined?(::Pitchfork) || defined?(::Unicorn))
         require "promenade/raindrops/middleware"
         Rails.application.config.middleware.use Promenade::Raindrops::Middleware
       end

--- a/lib/promenade/raindrops/middleware.rb
+++ b/lib/promenade/raindrops/middleware.rb
@@ -19,7 +19,14 @@ module Promenade
       private
 
         def tcp_listener_names
-          ::Pitchfork.listener_names
+          if defined?(::Pitchfork)
+            ::Pitchfork.listener_names
+          elsif defined?(::Unicorn)
+            ::Unicorn.listener_names
+          else
+            raise StandardError,
+              "Promenade::Raindrops::Middleware expects either ::Pitchfork or ::Unicorn to be defined"
+          end
         end
 
         def instrument

--- a/spec/promenade/raindrops/middleware_spec.rb
+++ b/spec/promenade/raindrops/middleware_spec.rb
@@ -3,19 +3,48 @@ require "promenade/raindrops/middleware"
 RSpec.describe Promenade::Raindrops::Middleware do
   let(:app) { double(:app, call: nil) }
   let(:listener_address) { "127.0.0.1:#{ENV.fetch('PORT', 3000)}" }
-  let(:pitchfork) { class_double("Pitchfork").as_stubbed_const }
 
-  before do
-    allow(pitchfork).to receive(:listener_names).and_return([listener_address])
+  shared_examples "middleware" do
+    it "is add it's instrumentaion to the rack.after_reply" do
+      stats = class_spy("Promenade::Raindrops::Stats").as_stubbed_const
+
+      after_reply = []
+      described_class.new(app).call({ "rack.after_reply" => after_reply })
+      after_reply.each(&:call)
+
+      expect(stats).to have_received(:instrument).with(listener_address: listener_address)
+    end
   end
 
-  it "is add it's instrumentaion to the rack.after_reply" do
-    stats = class_spy("Promenade::Raindrops::Stats").as_stubbed_const
+  context "when Pitchfork is defined" do
+    let(:pitchfork) { class_double("Pitchfork").as_stubbed_const }
 
-    after_reply = []
-    described_class.new(app).call({ "rack.after_reply" => after_reply })
-    after_reply.each(&:call)
+    before do
+      allow(pitchfork).to receive(:listener_names).and_return([listener_address])
+    end
 
-    expect(stats).to have_received(:instrument).with(listener_address: listener_address)
+    it_behaves_like "middleware"
+  end
+
+  context "when Unicorn is defined" do
+    let(:unicorn) { class_double("Unicorn").as_stubbed_const }
+
+    before do
+      allow(unicorn).to receive(:listener_names).and_return([listener_address])
+    end
+
+    it_behaves_like "middleware"
+  end
+
+  context "when neither Pitchfork nor Unicorn is defined" do
+    it "raises an error" do
+      stats = class_spy("Promenade::Raindrops::Stats").as_stubbed_const
+
+      expect do
+        after_reply = []
+        described_class.new(app).call({ "rack.after_reply" => after_reply })
+        after_reply.each(&:call)
+      end.to raise_error "Promenade::Raindrops::Middleware expects either ::Pitchfork or ::Unicorn to be defined"
+    end
   end
 end


### PR DESCRIPTION
#66 introduced Promenade::Raindrops::Middleware which exports Pitchfork worker metrics gathered by raindrops gem. This PR enables the middleware to export worker metrics when Unicorn is used instead of Pitchfork.