### PR TITLE
Combine memory statistics into a single metric with labels

### DIFF
--- a/lib/promenade/pitchfork/mem_stats.rb
+++ b/lib/promenade/pitchfork/mem_stats.rb
@@ -11,7 +11,6 @@ module Promenade
         doc "Memory usage in bytes, broken down by type (RSS, PSS, SHARED_MEMORY)"
       end
 
-
       def initialize
         return unless defined?(::Pitchfork) && defined?(::Pitchfork::MemInfo)
 

--- a/lib/promenade/pitchfork/mem_stats.rb
+++ b/lib/promenade/pitchfork/mem_stats.rb
@@ -7,24 +7,21 @@ end
 module Promenade
   module Pitchfork
     class MemStats
-      Promenade.gauge :pitchfork_mem_rss do
-        doc "Resident Set Size of the pitchfork process, Total memory used by the process."
+      Promenade.gauge :pitchfork_memory_usage_bytes do
+        doc "Memory usage in bytes, broken down by type (RSS, PSS, SHARED_MEMORY)"
       end
 
-      Promenade.gauge :pitchfork_shared_mem do
-        doc "Shared memory of the pitchfork process, memory that is shared between multiple processes."
-      end
 
       def initialize
         return unless defined?(::Pitchfork) && defined?(::Pitchfork::MemInfo)
 
         @mem_info = ::Pitchfork::MemInfo.new(Process.pid)
-        @parent_mem_info = ::Pitchfork::MemInfo.new(Process.ppid)
       end
 
       def instrument
-        Promenade.metric(:pitchfork_mem_rss).set({}, @mem_info.rss)
-        Promenade.metric(:pitchfork_shared_mem).set({}, @mem_info.shared_memory)
+        Promenade.metric(:pitchfork_memory_usage_bytes).set({ type: "RSS" }, @mem_info.rss * 1024)
+        Promenade.metric(:pitchfork_memory_usage_bytes).set({ type: "PSS" }, @mem_info.pss * 1024)
+        Promenade.metric(:pitchfork_memory_usage_bytes).set({ type: "Shared" }, @mem_info.shared_memory * 1024)
       end
 
       def self.instrument

--- a/spec/promenade/pitchfork/mem_stats_spec.rb
+++ b/spec/promenade/pitchfork/mem_stats_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Promenade::Pitchfork::MemStats do
     stub_const("Pitchfork::MemInfo", pitfork_mem_info)
     allow(pitfork_mem_info).to receive(:new).and_return(pitfork_mem_info)
     allow(pitfork_mem_info).to receive(:rss).and_return(100)
+    allow(pitfork_mem_info).to receive(:pss).and_return(50)
     allow(pitfork_mem_info).to receive(:shared_memory).and_return(50)
   end
 
@@ -22,11 +23,11 @@ RSpec.describe Promenade::Pitchfork::MemStats do
     it "sets the metrics correctly" do
       stats = Promenade::Pitchfork::MemStats.new
 
-      expect(Promenade).to receive(:metric).with(:pitchfork_mem_rss).and_return(metric)
-      expect(Promenade).to receive(:metric).with(:pitchfork_shared_mem).and_return(metric)
+      expect(Promenade).to receive(:metric).with(:pitchfork_memory_usage_bytes).and_return(metric)
 
-      expect(metric).to receive(:set).with({}, 100)
-      expect(metric).to receive(:set).with({}, 50)
+      expect(metric).to receive(:set).with({ type: "RSS" }, 102400)
+      expect(metric).to receive(:set).with({ type: "PSS" }, 51200)
+      expect(metric).to receive(:set).with({ type: "Shared" }, 51200)
 
       stats.instrument
     end


### PR DESCRIPTION
## What

Combine memory statistics into a single metric with labels. Additionally, now we are tracking PSS, which provides a more accurate representation of how much physical memory is uniquely and proportionally used by a process, especially in systems where many processes share memory.

## Why

However, a single metric is enough to track the three key metrics for each worker: RSS, PSS, and Shared Memory. Pitchfork utilizes `/proc/[pid]/smaps_rollup` to report these values.


## Anything else


`/proc/[pid]/smaps_rollup`  reports its metrics to kilobytes, I'm adding bytes sufix to the metric name

