### PR TITLE
Reduce http_request_queue_time_seconds cardinality + refactor

### DIFF
--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -20,7 +20,7 @@ module Promenade
         private
 
           def trace(env)
-            record_request_queue_time(env: env)
+            record_request_queue_time(env:)
             yield
           end
 

--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -14,40 +14,28 @@ module Promenade
         def initialize(app,
                        registry: ::Prometheus::Client.registry,
                        label_builder: RequestLabeler)
-          @queue_time_buckets = Promenade.configuration.queue_time_buckets
-
           super
         end
 
         private
 
-          attr_reader :queue_time_buckets
-
           def trace(env)
-            start_timestamp = Time.now.utc
-            response = yield
-            record_request_queue_time(labels: labels(env, response),
-              env: env,
-              request_received_time: start_timestamp)
-            response
+            record_request_queue_time(env: env)
+            yield
           end
 
-          def record_request_queue_time(labels:, env:, request_received_time:)
-            queue_time_seconds = QueueTimeDuration.new(env:, request_received_time:).queue_time_seconds
-            queue_time_seconds && queue_time_histogram.observe(labels, queue_time_seconds)
+          def record_request_queue_time(env:)
+            queue_time_seconds = QueueTimeDuration.new(env:).queue_time_seconds
+            queue_time_seconds && queue_time_histogram.observe(label_builder.call(env), queue_time_seconds)
           end
 
           def register_metrics!
             registry.histogram(REQUEST_QUEUE_TIME_HISTOGRAM_NAME,
-              "A histogram of request queue time", {}, queue_time_buckets)
+              "A histogram of request queue time", {}, Promenade.configuration.queue_time_buckets)
           end
 
           def queue_time_histogram
             registry.get(REQUEST_QUEUE_TIME_HISTOGRAM_NAME)
-          end
-
-          def labels(env, _)
-            label_builder.call(env)
           end
       end
     end

--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -33,11 +33,9 @@ module Promenade
           end
 
           def record_request_queue_time(labels:, env:, request_received_time:)
-            request_queue_duration = QueueTimeDuration.new(env:,
-              request_received_time:)
-            return unless request_queue_duration.valid_header_present?
-
-            queue_time_histogram.observe(labels, request_queue_duration.queue_time_seconds)
+            request_queue_duration = QueueTimeDuration.new(env:, request_received_time:).queue_time_seconds
+            return unless request_queue_duration
+            queue_time_histogram.observe(labels, request_queue_duration)
           end
 
           def register_metrics!

--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -33,9 +33,8 @@ module Promenade
           end
 
           def record_request_queue_time(labels:, env:, request_received_time:)
-            request_queue_duration = QueueTimeDuration.new(env:, request_received_time:).queue_time_seconds
-            return unless request_queue_duration
-            queue_time_histogram.observe(labels, request_queue_duration)
+            queue_time_seconds = QueueTimeDuration.new(env:, request_received_time:).queue_time_seconds
+            queue_time_seconds && queue_time_histogram.observe(labels, queue_time_seconds)
           end
 
           def register_metrics!

--- a/lib/promenade/client/rack/http_request_queue_time_collector.rb
+++ b/lib/promenade/client/rack/http_request_queue_time_collector.rb
@@ -48,6 +48,10 @@ module Promenade
           def queue_time_histogram
             registry.get(REQUEST_QUEUE_TIME_HISTOGRAM_NAME)
           end
+
+          def labels(env, _)
+            label_builder.call(env)
+          end
       end
     end
   end

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -9,7 +9,6 @@ module Promenade
         HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/
 
         def initialize(env:, request_received_time:)
-          @env = env
           @request_queued_time = extract_request_queued_time_from_env(env)
           @valid_header_present = @request_queued_time.is_a?(Float)
           @request_received_time = request_received_time.utc.to_f
@@ -29,7 +28,7 @@ module Promenade
 
         private
 
-          attr_reader :env, :request_queued_time, :request_received_time
+          attr_reader :request_queued_time, :request_received_time
 
           def queue_time
             request_received_time - request_queued_time

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -27,7 +27,7 @@ module Promenade
           end
 
           def extract_request_queued_time_from_env(env_hash)
-            header_value = env_hash[REQUEST_START_HEADER] || env_hash[QUEUE_START_HEADER]
+            header_value = env_hash.values_at(REQUEST_START_HEADER, QUEUE_START_HEADER).compact.first
             return if header_value.nil?
 
             header_time_match = header_value.to_s.match(HEADER_VALUE_MATCHER)

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -7,29 +7,32 @@ module Promenade
 
         HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/
 
-        def initialize(env:, request_received_time:)
-          @request_queued_time = extract_request_queued_time_from_env(env)
+        def initialize(env:, request_received_time: Time.now.utc)
+          @request_enqueued_time = request_enqueued_time_from(env)
           @request_received_time = request_received_time.utc.to_f
           freeze
         end
 
         def queue_time_seconds
-          # Don't collect negative queue times they are not valid
-          return unless queue_time > 0
-          queue_time&.round(3)
+          # Enqueued time could not be parsed from headers
+          return unless request_enqueued_time
+
+          # A negative queue time is not valid
+          return if queue_time < 0
+
+          queue_time.round(3)
         end
 
         private
 
-          attr_reader :request_queued_time, :request_received_time
+          attr_reader :request_enqueued_time, :request_received_time
 
           def queue_time
-            return unless request_queued_time
-            request_received_time - request_queued_time
+            request_received_time - request_enqueued_time
           end
 
-          def extract_request_queued_time_from_env(env_hash)
-            header_value = env_hash.values_at(REQUEST_START_HEADER, QUEUE_START_HEADER).compact.first
+          def request_enqueued_time_from(env)
+            header_value = env.values_at(REQUEST_START_HEADER, QUEUE_START_HEADER).compact.first
             return if header_value.nil?
 
             header_time_match = header_value.to_s.match(HEADER_VALUE_MATCHER)

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -14,6 +14,8 @@ module Promenade
         end
 
         def queue_time_seconds
+          # Don't collect negative queue times they are not valid
+          return unless queue_time > 0
           queue_time&.round(3)
         end
 

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -10,9 +10,9 @@ module Promenade
 
         def initialize(env:, request_received_time:)
           @env = env
-          @request_queued_time_ms = extract_request_queued_time_from_env(env)
-          @valid_header_present = @request_queued_time_ms.is_a?(Float)
-          @request_received_time_ms = request_received_time.utc.to_f
+          @request_queued_time = extract_request_queued_time_from_env(env)
+          @valid_header_present = @request_queued_time.is_a?(Float)
+          @request_received_time = request_received_time.utc.to_f
 
           freeze
         end
@@ -29,10 +29,10 @@ module Promenade
 
         private
 
-          attr_reader :env, :request_queued_time_ms, :request_received_time_ms
+          attr_reader :env, :request_queued_time, :request_received_time
 
           def queue_time
-            request_received_time_ms - request_queued_time_ms
+            request_received_time - request_queued_time
           end
 
           def extract_request_queued_time_from_env(env_hash)

--- a/lib/promenade/client/rack/queue_time_duration.rb
+++ b/lib/promenade/client/rack/queue_time_duration.rb
@@ -3,27 +3,18 @@ module Promenade
     module Rack
       class QueueTimeDuration
         REQUEST_START_HEADER = "HTTP_X_REQUEST_START".freeze
-
         QUEUE_START_HEADER = "HTTP_X_QUEUE_START".freeze
 
         HEADER_VALUE_MATCHER = /^(?:t=)(?<timestamp>\d{10}(?:\.\d+))$/
 
         def initialize(env:, request_received_time:)
           @request_queued_time = extract_request_queued_time_from_env(env)
-          @valid_header_present = @request_queued_time.is_a?(Float)
           @request_received_time = request_received_time.utc.to_f
-
           freeze
         end
 
-        def valid_header_present?
-          @valid_header_present
-        end
-
         def queue_time_seconds
-          return unless valid_header_present?
-
-          queue_time.round(3)
+          queue_time&.round(3)
         end
 
         private
@@ -31,6 +22,7 @@ module Promenade
           attr_reader :request_queued_time, :request_received_time
 
           def queue_time
+            return unless request_queued_time
             request_received_time - request_queued_time
           end
 

--- a/lib/promenade/client/rack/request_controller_action_labeler.rb
+++ b/lib/promenade/client/rack/request_controller_action_labeler.rb
@@ -15,11 +15,14 @@ module Promenade
 
         SEPARATOR = "#".freeze
 
-        private_constant :PARAMS_KEY, :CONTROLLER, :ACTION, :UNKNOWN, :SEPARATOR
+        REQUEST_METHOD = "REQUEST_METHOD".freeze
+
+        private_constant :PARAMS_KEY, :CONTROLLER, :ACTION, :UNKNOWN, :SEPARATOR, :REQUEST_METHOD
 
         def call(env)
           super.merge({
             controller_action: controller_action_from_env(env),
+            method: env[REQUEST_METHOD].to_s.downcase,
           })
         end
 

--- a/lib/promenade/client/rack/request_labeler.rb
+++ b/lib/promenade/client/rack/request_labeler.rb
@@ -5,15 +5,12 @@ module Promenade
         require_relative "singleton_caller"
         extend SingletonCaller
 
-        REQUEST_METHOD = "REQUEST_METHOD".freeze
-
         HTTP_HOST = "HTTP_HOST".freeze
 
-        private_constant :REQUEST_METHOD, :HTTP_HOST
+        private_constant :HTTP_HOST
 
         def call(env)
           {
-            method: env[REQUEST_METHOD].to_s.downcase,
             host: env[HTTP_HOST].to_s,
           }
         end

--- a/spec/integration/queue_time_recording_spec.rb
+++ b/spec/integration/queue_time_recording_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe "Queue time recording", type: :request do
     histogram = Prometheus::Client.registry.get(:http_request_queue_time_seconds)
     expected_queue_time = 0.01
     expected_labels = {
-      code: "200",
       host: "www.example.com",
-      method: "get",
     }
 
     expect(histogram).to receive(:observe).with(expected_labels, expected_queue_time)
@@ -33,9 +31,7 @@ RSpec.describe "Queue time recording", type: :request do
     histogram = Prometheus::Client.registry.get(:http_request_queue_time_seconds)
     expected_queue_time = 0.01
     expected_labels = {
-      code: "200",
       host: "www.example.com",
-      method: "get",
     }
 
     expect(histogram).to receive(:observe).with(expected_labels, expected_queue_time)

--- a/spec/promenade/client/rack/http_request_queue_time_collector_spec.rb
+++ b/spec/promenade/client/rack/http_request_queue_time_collector_spec.rb
@@ -1,0 +1,165 @@
+require "spec_helper"
+require "promenade/client/rack/http_request_queue_time_collector"
+require "active_support/testing/time_helpers"
+require "rack/mock"
+require "support/test_rack_app"
+require "support/queue_time_header_helpers"
+
+RSpec.describe Promenade::Client::Rack::HTTPRequestQueueTimeCollector, reset_prometheus_client: true do
+  include ActiveSupport::Testing::TimeHelpers
+  include QueueTimeHeaderHelpers
+
+  describe "#call" do
+    it "preserves the status code" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(status: 418)
+      middleware = described_class.new(app)
+      status, = middleware.call(env)
+
+      expect(status).to eql(418)
+    end
+
+    it "preserves the headers" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(headers: { "HTTP_FIZZ" => "buzz" })
+      middleware = described_class.new(app)
+      _, headers, = middleware.call(env)
+
+      expect(headers).to eql("HTTP_FIZZ" => "buzz")
+    end
+
+    it "preserves the body" do
+      env = Rack::MockRequest.env_for
+      app = TestRackApp.new(body: "test-body")
+      middleware = described_class.new(app)
+      _, _, body = middleware.call(env)
+
+      expect(body).to eql("test-body")
+    end
+
+    it "records a histogram for the queue time when X-Request-Start is present" do
+      freeze_time
+      queued_at = Time.now.utc - 1.0
+      env = Rack::MockRequest.env_for("/",
+        "HTTP_HOST" => "test.host",
+        "HTTP_X_REQUEST_START" => request_start_timestamp(queued_at))
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expect(histogram).to receive(:observe)
+
+      middleware.call(env)
+    end
+
+    it "records a histogram with host label and measured queue duration" do
+      freeze_time
+      queued_at = Time.now.utc - 1.0
+      env = Rack::MockRequest.env_for("/",
+        "HTTP_HOST" => "test.host",
+        "HTTP_X_REQUEST_START" => request_start_timestamp(queued_at))
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expected_labels = { host: "test.host" }
+
+      expect(histogram).to receive(:observe).with(expected_labels, 1.0)
+
+      middleware.call(env)
+    end
+
+    it "records using X-Queue-Start when X-Request-Start is absent" do
+      freeze_time
+      queued_at = Time.now.utc - 2.0
+      env = Rack::MockRequest.env_for("/",
+        "HTTP_HOST" => "test.host",
+        "HTTP_X_QUEUE_START" => request_start_timestamp(queued_at))
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expected_labels = { host: "test.host" }
+
+      expect(histogram).to receive(:observe).with(expected_labels, 2.0)
+
+      middleware.call(env)
+    end
+
+    it "does not record when no queue header is present" do
+      freeze_time
+      env = Rack::MockRequest.env_for("/", "HTTP_HOST" => "test.host")
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expect(histogram).not_to receive(:observe)
+
+      middleware.call(env)
+    end
+
+    it "does not record when the header value is not a valid t= timestamp" do
+      freeze_time
+      env = Rack::MockRequest.env_for("/",
+        "HTTP_HOST" => "test.host",
+        "HTTP_X_REQUEST_START" => Time.now.utc.to_s)
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expect(histogram).not_to receive(:observe)
+
+      middleware.call(env)
+    end
+
+    it "accepts a custom block for histogram labels" do
+      freeze_time
+      queued_at = Time.now.utc - 0.5
+      env = Rack::MockRequest.env_for("/",
+        "fizz" => "buzz",
+        "HTTP_X_REQUEST_START" => request_start_timestamp(queued_at))
+      app = TestRackApp.new
+      custom_label_builder = proc { |_env| { foo: "bar", fizz: _env["fizz"] } }
+      middleware = described_class.new(app, label_builder: custom_label_builder)
+
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+      expected_labels = { foo: "bar", fizz: "buzz" }
+
+      expect(histogram).to receive(:observe).with(expected_labels, 0.5)
+
+      middleware.call(env)
+    end
+
+    it "accepts a custom set of queue time histogram buckets" do
+      Promenade.configure do |config|
+        config.queue_time_buckets = [0.1, 0.5, 1.0]
+      end
+
+      freeze_time
+      queued_at = Time.now.utc - 0.5
+      env = Rack::MockRequest.env_for("/",
+        "HTTP_HOST" => "test.host",
+        "HTTP_X_REQUEST_START" => request_start_timestamp(queued_at))
+      app = TestRackApp.new
+      middleware = described_class.new(app)
+      expected_labels = { host: "test.host" }
+      histogram = fetch_metric(:http_request_queue_time_seconds)
+
+      middleware.call(env)
+
+      normalized_histogram_values = histogram_values_to_h(histogram, expected_labels)
+      expect(normalized_histogram_values).to eq({ 0.1 => 0.0, 0.5 => 1.0, 1.0 => 1.0 })
+    end
+  end
+
+  private
+
+    def fetch_metric(metric_name)
+      Prometheus::Client.registry.get(metric_name.to_sym)
+    end
+
+    def histogram_values_to_h(histogram, expected_labels)
+      histogram_values = histogram.values[expected_labels]
+      histogram_values.transform_values(&:get)
+    end
+end

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -9,19 +9,18 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
 
 
   describe "#queue_time_seconds" do
-    it "returns nil when no queue header present" do
-      duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: {},
-        request_received_time: Time.now.utc,
-      )
+    before do
+      freeze_time
+    end
 
+    it "returns nil when no queue header present" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(env: {})
       expect(duration.queue_time_seconds).to be_nil
     end
 
     it "returns nil when queue header is Timestamp format" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => Time.now.utc.to_s },
-        request_received_time: Time.now.utc,
       )
 
       expect(duration.queue_time_seconds).to be_nil
@@ -30,91 +29,72 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
     it "returns nil when queue header is an invalid Integer" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => 1234 },
-        request_received_time: Time.now.utc,
       )
 
       expect(duration.queue_time_seconds).to be_nil
     end
 
     it "returns the correct value when queue header is present and a valid value" do
-      env = {}
-      freeze_time
-      travel_to(Time.now.utc - 2) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
-      travel_to(Time.now.utc)
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: env,
-        request_received_time: Time.now.utc,
+        env: {
+          "HTTP_X_QUEUE_START" => request_start_timestamp(Time.now.utc - 2),
+        },
       )
       expect(duration.queue_time_seconds).to eql(2.0)
     end
 
     it "prioritises HTTP_X_REQUEST_START before HTTP_X_QUEUE_START" do
-      env = {}
-      freeze_time
-      travel_to(Time.now.utc - 10) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
-      travel_to(Time.now.utc - 5) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
-      travel_to(Time.now.utc)
-
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: env,
-        request_received_time: Time.now.utc,
+        env: {
+          "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc - 10),
+          "HTTP_X_QUEUE_START" => request_start_timestamp(Time.now.utc - 5),
+        }
       )
 
       expect(duration.queue_time_seconds).to eql(10.0)
 
       # Perform same expectation as above, but with the values flipped. This way
       # we can ensure we're testing the priority of the headers
-      travel_to(Time.now.utc - 10) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
-      travel_to(Time.now.utc - 5) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
-      travel_to(Time.now.utc)
-
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: env,
-        request_received_time: Time.now.utc,
+        env: {
+          "HTTP_X_QUEUE_START" => request_start_timestamp(Time.now.utc - 10),
+          "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc - 5),
+        }
       )
 
       expect(duration.queue_time_seconds).to eql(5.0)
     end
 
-    it "returns nil when neither HTTP_X_REQUEST_START nor HTTP_X_QUEUE_START is present" do
-      duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: {},
-        request_received_time: Time.now.utc,
-      )
-
-      expect(duration.queue_time_seconds).to be(nil)
-    end
-
     it "returns nil when the header is present but has no 't=' prefix" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => Time.now.to_f.to_s },
-        request_received_time: Time.now.utc,
       )
 
-      expect(duration.queue_time_seconds).to be(nil)
+      expect(duration.queue_time_seconds).to be_nil
     end
 
     it "returns nil when the header is present but has invalid timestamp" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => "invalid-value" },
-        request_received_time: Time.now.utc,
       )
 
-      expect(duration.queue_time_seconds).to be(nil)
+      expect(duration.queue_time_seconds).to be_nil
     end
 
     it "returns the difference between queue time and received time when valid" do
-      freeze_time
-      env = Hash.new
-
-      travel_to(Time.now.utc - 10) { env["HTTP_X_REQUEST_START"] = request_start_timestamp }
-      travel_to(Time.now.utc)
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: env,
-        request_received_time: Time.now.utc,
+        env: { "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc - 10) },
       )
 
       expect(duration.queue_time_seconds).to eq(10.0)
+    end
+
+    it "returns nil if the request was enqueued after the request was received" do
+      duration = Promenade::Client::Rack::QueueTimeDuration.new(
+        env: { "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc + 10) },
+      )
+
+      expect(duration.queue_time_seconds).to be_nil
     end
   end
 end

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
         env: {
           "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc - 10),
           "HTTP_X_QUEUE_START" => request_start_timestamp(Time.now.utc - 5),
-        }
+        },
       )
 
       expect(duration.queue_time_seconds).to eql(10.0)
@@ -59,7 +59,7 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
         env: {
           "HTTP_X_QUEUE_START" => request_start_timestamp(Time.now.utc - 10),
           "HTTP_X_REQUEST_START" => request_start_timestamp(Time.now.utc - 5),
-        }
+        },
       )
 
       expect(duration.queue_time_seconds).to eql(5.0)

--- a/spec/promenade/client/rack/queue_time_duration_spec.rb
+++ b/spec/promenade/client/rack/queue_time_duration_spec.rb
@@ -7,47 +7,47 @@ RSpec.describe Promenade::Client::Rack::QueueTimeDuration do
   include ActiveSupport::Testing::TimeHelpers
   include QueueTimeHeaderHelpers
 
-  describe "#valid_header_present?" do
-    it "returns false when no queue header present" do
+
+  describe "#queue_time_seconds" do
+    it "returns nil when no queue header present" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: {},
         request_received_time: Time.now.utc,
       )
 
-      expect(duration.valid_header_present?).to be(false)
+      expect(duration.queue_time_seconds).to be_nil
     end
 
-    it "returns false when queue header is Timestamp format" do
+    it "returns nil when queue header is Timestamp format" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => Time.now.utc.to_s },
         request_received_time: Time.now.utc,
       )
 
-      expect(duration.valid_header_present?).to be(false)
+      expect(duration.queue_time_seconds).to be_nil
     end
 
-    it "returns false when queue header is an invalid Integer" do
+    it "returns nil when queue header is an invalid Integer" do
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
         env: { "HTTP_X_REQUEST_START" => 1234 },
         request_received_time: Time.now.utc,
       )
 
-      expect(duration.valid_header_present?).to be(false)
+      expect(duration.queue_time_seconds).to be_nil
     end
 
-    it "returns true when queue header is present and a valid value" do
+    it "returns the correct value when queue header is present and a valid value" do
+      env = {}
       freeze_time
+      travel_to(Time.now.utc - 2) { env["HTTP_X_QUEUE_START"] = request_start_timestamp }
+      travel_to(Time.now.utc)
       duration = Promenade::Client::Rack::QueueTimeDuration.new(
-        env: { "HTTP_X_REQUEST_START" => request_start_timestamp },
+        env: env,
         request_received_time: Time.now.utc,
       )
-      travel_to Time.now.utc + 2 do
-        expect(duration.valid_header_present?).to be(true)
-      end
+      expect(duration.queue_time_seconds).to eql(2.0)
     end
-  end
 
-  describe "#queue_time_seconds" do
     it "prioritises HTTP_X_REQUEST_START before HTTP_X_QUEUE_START" do
       env = {}
       freeze_time

--- a/spec/promenade/client/rack/request_labeler_spec.rb
+++ b/spec/promenade/client/rack/request_labeler_spec.rb
@@ -12,25 +12,5 @@ RSpec.describe Promenade::Client::Rack::RequestLabeler, reset_prometheus_client:
 
       expect(labels).to include(host: "test-host")
     end
-
-    it "sets the method from env REQUEST_METHOD" do
-      env_hash = {
-        "REQUEST_METHOD" => "test-method",
-      }
-
-      labels = described_class.call(env_hash)
-
-      expect(labels).to include(method: "test-method")
-    end
-
-    it "converts the method to lower-case string" do
-      env_hash = {
-        "REQUEST_METHOD" => "TEST-METHOD",
-      }
-
-      labels = described_class.call(env_hash)
-
-      expect(labels).to include(method: "test-method")
-    end
   end
 end


### PR DESCRIPTION
Reduce the cardinality of http_request_queue_time_seconds

Currently we are recording this histogram for each action/controller/method.

This isn't really required since queue time is a function of how many requests (and how long they take to process) at the server level.  The currently requested action/controller/method has no impact on this (since at the time we measure queue time we haven't even started processing the request yet).

Also a little refactoring to improve readability, I also added some specs around the middleware.