### PR TITLE
Upgrade golang version to 1.26.2

### DIFF
--- a/exporter/Dockerfile
+++ b/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-trixie AS builder
+FROM golang:1.26.2-trixie AS builder
 
 WORKDIR /src
 

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/errm/promenade/exporter
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/alexflint/go-arg v1.6.1


### PR DESCRIPTION
Fixes some stdlib vulns

* https://pkg.go.dev/vuln/GO-2026-4599
* https://pkg.go.dev/vuln/GO-2026-4600
* https://pkg.go.dev/vuln/GO-2026-4601
* https://pkg.go.dev/vuln/GO-2026-4602
* https://pkg.go.dev/vuln/GO-2026-4866
* https://pkg.go.dev/vuln/GO-2026-4870
* https://pkg.go.dev/vuln/GO-2026-4946
* https://pkg.go.dev/vuln/GO-2026-4947