### PR TITLE
peak tcp connection stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ Acceptance tests require Docker: `bundle exec rake acceptance:spec`
 
 ```sh
 cd exporter
-go test -v ./...                                           # All tests
+make test                                                  # All tests (via Docker — works on macOS)
+go test -v ./...                                           # All tests (Linux only)
 go test -v ./multiprocess -run TestCollector_Collect/gauge # Single test
 go vet ./...                                               # Vet
 golangci-lint run                                          # Lint

--- a/exporter/Makefile
+++ b/exporter/Makefile
@@ -1,0 +1,16 @@
+GO_IMAGE := golang:1.26.2-trixie
+
+# Run the full test suite inside a Linux container.
+# This is the canonical way to run tests on non-Linux hosts (e.g. macOS),
+# since the tcpconnections tests require Linux kernel interfaces.
+# Build and module caches are persisted in named Docker volumes so
+# subsequent runs don't re-download dependencies or recompile from scratch.
+.PHONY: test
+test:
+	docker run --rm \
+		-v "$(CURDIR):/src" \
+		-v "promenade-go-build-cache:/root/.cache/go-build" \
+		-v "promenade-go-mod-cache:/go/pkg/mod" \
+		-w /src \
+		$(GO_IMAGE) \
+		go test -v ./...

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -25,3 +25,24 @@ and connections that have not yet been processed (queing).
 without any need for the ruby native extension.
 * Implimentation details are significantly simpler than raindrops, due to robust
 and easy to use libaries for dealing with netlink and socket statistics.
+## Deployment
+
+The exporter runs as a sidecar container sharing a network namespace and tmpfs volume with the application container. See the [`compose.yml`](../compose.yml) at the root of this repo for a reference deployment.
+
+## Development
+
+### Running tests
+
+The TCP connection tests use Linux kernel interfaces and must run on Linux. On macOS (or any non-Linux host), use:
+
+```sh
+make test
+```
+
+This runs the full test suite inside a Linux Docker container using the same Go version as the production image. Build and module caches are persisted in named Docker volumes so subsequent runs are fast.
+
+On Linux you can run tests directly:
+
+```sh
+go test -v ./...
+```

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -1,30 +1,38 @@
 # promenade exporter
 
-A prometheus exporter for ruby applications (written in go)
+A Prometheus exporter for Ruby applications, written in Go.
 
-# Why
+## Why
 
-Promenade was allways designed to minimise the impact of
-metrics collection on the ruby application server.
+Promenade is designed to minimise the impact of metrics collection on the Ruby application server. Running the exporter as a sidecar container means Prometheus scrapes never touch the Ruby process.
 
-Thus it was recomended to run a sidecar container (with a simple
-server) to export metrics collected by the application server.
+The exporter reads metrics files written directly by the Ruby application, so there is no in-process HTTP server needed on the Ruby side.
 
-This takes this a step further, by reading metrics written by
-the application server in a lightwight go based exporter.
+## Metrics
 
-# multiprocess metrics
-* Reads multiprocess metrics written by prometheus-client-mmap
-* Exposes them as prometheus metrics
+### Multiprocess metrics
 
-# rack server metrics
+Reads the mmap `.db` files written by `prometheus-client-mmap` from the shared `PROMETHEUS_MULTIPROC_DIR` directory and exposes them as standard Prometheus metrics.
 
-* Reports the current number of in process connections (busy workers)
-and connections that have not yet been processed (queing).
-* Collects these metrics via netlink / diag like raindrops, but
-without any need for the ruby native extension.
-* Implimentation details are significantly simpler than raindrops, due to robust
-and easy to use libaries for dealing with netlink and socket statistics.
+### TCP connection metrics
+
+Reports `tcp_active_connections_peak` and `tcp_queued_connections_peak` — the high-water mark number of active and queued connections for each listener port, sampled via Linux netlink (SOCK_DIAG) — the same data source as raindrops, but without any native Ruby extension.
+
+Rather than sampling at scrape time, the exporter polls netlink frequently and tracks the peak value seen since the last bucket rotation. This avoids missing short-lived spikes that would be invisible to a single point-in-time sample.
+
+Two buckets (current and previous) are maintained, rotating at half the window duration. On each scrape the exporter returns `max(current, previous)`, so multiple Prometheus instances in an HA setup see consistent values regardless of when they scrape.
+
+## Configuration
+
+All options can be set via flag or environment variable.
+
+| Flag | Env var | Default | Description |
+|---|---|---|---|
+| `--metrics-port` | `PORT` | `9394` | Port to serve metrics on |
+| `--multiprocess-dir` | `PROMETHEUS_MULTIPROC_DIR` | `/app/tmp/promenade` | Directory to read multiprocess metrics from |
+| `--tcp-sampling-interval` | `TCP_SAMPLING_INTERVAL` | `25ms` | How often to poll netlink for TCP connection counts |
+| `--tcp-hwm-window` | `TCP_HWM_WINDOW` | `30s` | High-water mark window; should match your Prometheus scrape interval |
+
 ## Deployment
 
 The exporter runs as a sidecar container sharing a network namespace and tmpfs volume with the application container. See the [`compose.yml`](../compose.yml) at the root of this repo for a reference deployment.

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -20,7 +20,7 @@ Reports `tcp_active_connections_peak` and `tcp_queued_connections_peak` — the 
 
 Rather than sampling at scrape time, the exporter polls netlink frequently and tracks the peak value seen since the last bucket rotation. This avoids missing short-lived spikes that would be invisible to a single point-in-time sample.
 
-Two buckets (current and previous) are maintained, rotating at half the window duration. On each scrape the exporter returns `max(current, previous)`, so multiple Prometheus instances in an HA setup see consistent values regardless of when they scrape.
+A ring buffer of three buckets is maintained, rotating at half the window duration. On each scrape the exporter returns the max across all buckets, guaranteeing a full window of lookback regardless of when the scrape falls relative to a rotation boundary. Multiple Prometheus instances in an HA setup see consistent values regardless of when they scrape.
 
 ## Configuration
 

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -20,7 +20,7 @@ Reports `tcp_active_connections_peak` and `tcp_queued_connections_peak` — the 
 
 Rather than sampling at scrape time, the exporter polls netlink frequently and tracks the peak value seen since the last bucket rotation. This avoids missing short-lived spikes that would be invisible to a single point-in-time sample.
 
-A ring buffer of three buckets is maintained, rotating at half the window duration. On each scrape the exporter returns the max across all buckets, guaranteeing a full window of lookback regardless of when the scrape falls relative to a rotation boundary. Multiple Prometheus instances in an HA setup see consistent values regardless of when they scrape.
+A ring buffer of `window/1s + 1` buckets rotates every second. On each scrape the exporter returns the max across all buckets, guaranteeing a full window of lookback with at most 1s of inaccuracy at any rotation boundary. Multiple Prometheus instances in an HA setup see consistent values regardless of when they scrape.
 
 ## Configuration
 

--- a/exporter/main.go
+++ b/exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/alexflint/go-arg"
 
@@ -15,8 +16,10 @@ import (
 )
 
 type args struct {
-	Port            int    `arg:"--metrics-port,env" help:"Port to serve metrics on" default:"9394"`
-	MultiprocessDir string `arg:"--multiprocess-dir,env:PROMETHEUS_MULTIPROC_DIR" help:"Directory to read multiprocess metrics from" default:"/app/tmp/promenade"`
+	Port             int           `arg:"--metrics-port,env:PORT" help:"Port to serve metrics on" default:"9394"`
+	MultiprocessDir  string        `arg:"--multiprocess-dir,env:PROMETHEUS_MULTIPROC_DIR" help:"Directory to read multiprocess metrics from" default:"/app/tmp/promenade"`
+	SamplingInterval time.Duration `arg:"--tcp-sampling-interval,env:TCP_SAMPLING_INTERVAL" help:"How often to sample TCP connection metrics" default:"25ms"`
+	HWMWindow        time.Duration `arg:"--tcp-hwm-window,env:TCP_HWM_WINDOW" help:"TCP high-water mark window; should match your Prometheus scrape interval" default:"30s"`
 }
 
 var cfg args
@@ -28,7 +31,7 @@ func init() {
 func main() {
 	reg := prometheus.NewRegistry()
 
-	serverMetricsCollector, err := tcpconnections.NewCollector()
+	serverMetricsCollector, err := tcpconnections.NewCollector(cfg.SamplingInterval, cfg.HWMWindow)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/exporter/main.go
+++ b/exporter/main.go
@@ -35,11 +35,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer func() {
-		if err = serverMetricsCollector.Close(); err != nil {
-			log.Println(err)
-		}
-	}()
 
 	reg.MustRegister(
 		serverMetricsCollector,
@@ -49,5 +44,9 @@ func main() {
 	addr := ":" + strconv.Itoa(cfg.Port)
 	log.Printf("Starting metrics server on %s", addr)
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(addr, nil))
+	serveErr := http.ListenAndServe(addr, nil)
+	if closeErr := serverMetricsCollector.Close(); closeErr != nil {
+		log.Println(closeErr)
+	}
+	log.Fatal(serveErr)
 }

--- a/exporter/main.go
+++ b/exporter/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/alexflint/go-arg"
@@ -42,11 +46,28 @@ func main() {
 	)
 
 	addr := ":" + strconv.Itoa(cfg.Port)
-	log.Printf("Starting metrics server on %s", addr)
+	srv := &http.Server{Addr: addr}
 	http.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
-	serveErr := http.ListenAndServe(addr, nil)
-	if closeErr := serverMetricsCollector.Close(); closeErr != nil {
-		log.Println(closeErr)
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		log.Printf("Starting metrics server on %s", addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatal(err)
+		}
+	}()
+
+	<-quit
+	log.Println("Shutting down")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("HTTP server shutdown error: %v", err)
 	}
-	log.Fatal(serveErr)
+	if err := serverMetricsCollector.Close(); err != nil {
+		log.Printf("Collector close error: %v", err)
+	}
 }

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -93,29 +93,57 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 // run is the background goroutine that samples netlink and rotates buckets.
 func (c *Collector) run() {
 	defer c.wg.Done()
-	c.sample()
+	if err := c.sample(); err != nil {
+		log.Printf("TCP connection sampling error: %v", err)
+	}
 	sampleTicker := time.NewTicker(c.interval)
 	rotateTicker := time.NewTicker(c.window / 2)
 	defer sampleTicker.Stop()
 	defer rotateTicker.Stop()
+	var backoff time.Duration
 	for {
 		select {
 		case <-c.done:
 			return
 		case <-sampleTicker.C:
-			c.sample()
+			if err := c.sample(); err != nil {
+				backoff = nextBackoff(backoff)
+				log.Printf("TCP connection sampling error (retrying in %s): %v", backoff, err)
+				select {
+				case <-time.After(backoff):
+				case <-c.done:
+					return
+				}
+			} else if backoff > 0 {
+				log.Println("TCP connection sampling recovered")
+				backoff = 0
+			}
 		case <-rotateTicker.C:
 			c.rotate()
 		}
 	}
 }
 
+// nextBackoff returns the next backoff duration, doubling from 1s up to 60s.
+func nextBackoff(current time.Duration) time.Duration {
+	const (
+		initial = time.Second
+		max     = 60 * time.Second
+	)
+	if current == 0 {
+		return initial
+	}
+	if next := current * 2; next < max {
+		return next
+	}
+	return max
+}
+
 // sample polls netlink and advances the current bucket high-water marks.
-func (c *Collector) sample() {
+func (c *Collector) sample() error {
 	metrics, err := c.collectMetrics()
 	if err != nil {
-		log.Println(err)
-		return
+		return err
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -130,6 +158,7 @@ func (c *Collector) sample() {
 		}
 		c.current[key] = hwm
 	}
+	return nil
 }
 
 // rotate moves the current bucket to previous and starts a fresh current bucket.

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -6,6 +6,8 @@ package tcpconnections
 import (
 	"fmt"
 	"log"
+	"sync"
+	"time"
 
 	"github.com/florianl/go-diag"
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,28 +20,13 @@ type NetlinkDumper interface {
 	Close() error
 }
 
-var (
-	// Metric descriptors - created once and reused
-	activeRequestsDesc = prometheus.NewDesc(
-		"tcp_active_connections",
-		"Number of active connections",
-		[]string{"listener"},
-		nil,
-	)
-	queuedRequestsDesc = prometheus.NewDesc(
-		"tcp_queued_connections",
-		"Number of connections in queue",
-		[]string{"listener"},
-		nil,
-	)
-)
-
-// Collector collects metrics about requests in progress and queuing.
-type Collector struct {
-	netlink NetlinkDumper
+// listenerHWM holds the high-water mark active and queued connection counts for a listener.
+type listenerHWM struct {
+	active int
+	queued int
 }
 
-// listenerMetrics holds the active and queued request counts for a listener.
+// listenerMetrics holds the active and queued request counts sampled from netlink.
 type listenerMetrics struct {
 	address string
 	port    uint16
@@ -47,45 +34,143 @@ type listenerMetrics struct {
 	queued  int
 }
 
-// NewCollector creates a new Collector with a real netlink connection.
-func NewCollector() (*Collector, error) {
+// Collector collects TCP connection metrics using a two-bucket high-water mark.
+// A background goroutine samples netlink every interval and advances the current
+// bucket upward. Every window/2 duration the bucket rotates: current becomes
+// previous and a fresh current starts. Collect returns max(current, previous),
+// making it safe for multiple Prometheus instances scraping at different times.
+type Collector struct {
+	netlink    NetlinkDumper
+	interval   time.Duration
+	window     time.Duration
+	activeDesc *prometheus.Desc
+	queuedDesc *prometheus.Desc
+	mu         sync.Mutex
+	current    map[string]listenerHWM
+	previous   map[string]listenerHWM
+	done       chan struct{}
+	wg         sync.WaitGroup
+}
+
+// NewCollector creates a new Collector and starts the background sampling loop.
+// interval controls how often netlink is polled. window should match your
+// Prometheus scrape interval; buckets rotate at window/2 internally so that
+// any scrape always covers at least one full rotation period.
+func NewCollector(interval, window time.Duration) (*Collector, error) {
 	nl, err := diag.Open(&diag.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("could not open netlink socket: %w", err)
 	}
-	return &Collector{
-		netlink: nl,
-	}, nil
+	c := &Collector{
+		netlink:  nl,
+		interval: interval,
+		window:   window,
+		activeDesc: prometheus.NewDesc(
+			"tcp_active_connections_peak",
+			fmt.Sprintf("Peak number of active TCP connections in the last %s", window),
+			[]string{"listener"}, nil,
+		),
+		queuedDesc: prometheus.NewDesc(
+			"tcp_queued_connections_peak",
+			fmt.Sprintf("Peak number of queued TCP connections in the last %s", window),
+			[]string{"listener"}, nil,
+		),
+		current:  make(map[string]listenerHWM),
+		previous: make(map[string]listenerHWM),
+		done:     make(chan struct{}),
+	}
+	c.wg.Add(1)
+	go c.run()
+	return c, nil
+}
+
+// run is the background goroutine that samples netlink and rotates buckets.
+func (c *Collector) run() {
+	defer c.wg.Done()
+	sampleTicker := time.NewTicker(c.interval)
+	rotateTicker := time.NewTicker(c.window / 2)
+	defer sampleTicker.Stop()
+	defer rotateTicker.Stop()
+	for {
+		select {
+		case <-c.done:
+			return
+		case <-sampleTicker.C:
+			c.sample()
+		case <-rotateTicker.C:
+			c.rotate()
+		}
+	}
+}
+
+// sample polls netlink and advances the current bucket high-water marks.
+func (c *Collector) sample() {
+	metrics, err := c.collectMetrics()
+	if err != nil {
+		log.Println(err)
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range metrics {
+		key := fmt.Sprintf("%s:%d", m.address, m.port)
+		hwm := c.current[key]
+		if m.active > hwm.active {
+			hwm.active = m.active
+		}
+		if m.queued > hwm.queued {
+			hwm.queued = m.queued
+		}
+		c.current[key] = hwm
+	}
+}
+
+// rotate moves the current bucket to previous and starts a fresh current bucket.
+func (c *Collector) rotate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.previous = c.current
+	c.current = make(map[string]listenerHWM)
 }
 
 // Describe implements prometheus.Collector.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- activeRequestsDesc
-	ch <- queuedRequestsDesc
+	ch <- c.activeDesc
+	ch <- c.queuedDesc
 }
 
-// Collect implements prometheus.Collector.
+// Collect implements prometheus.Collector. It returns max(current, previous)
+// for each listener and does not reset state, so multiple scrapers see
+// consistent values.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	listenerMetrics, err := c.collectMetrics()
-	if err != nil {
-		log.Println(err)
-		// If collection fails, we don't send any metrics
-		return
+	c.mu.Lock()
+	merged := make(map[string]listenerHWM, len(c.current)+len(c.previous))
+	for k, v := range c.previous {
+		merged[k] = v
 	}
+	for k, v := range c.current {
+		prev := merged[k]
+		if v.active > prev.active {
+			prev.active = v.active
+		}
+		if v.queued > prev.queued {
+			prev.queued = v.queued
+		}
+		merged[k] = prev
+	}
+	c.mu.Unlock()
 
-	// Emit metrics for each listener
-	for _, metrics := range listenerMetrics {
-		listener := fmt.Sprintf("%s:%d", metrics.address, metrics.port)
+	for listener, hwm := range merged {
 		ch <- prometheus.MustNewConstMetric(
-			activeRequestsDesc,
+			c.activeDesc,
 			prometheus.GaugeValue,
-			float64(metrics.active),
+			float64(hwm.active),
 			listener,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			queuedRequestsDesc,
+			c.queuedDesc,
 			prometheus.GaugeValue,
-			float64(metrics.queued),
+			float64(hwm.queued),
 			listener,
 		)
 	}
@@ -107,7 +192,6 @@ func (c *Collector) getSocketStats(state uint8) ([]diag.NetObject, error) {
 
 // collectMetrics collects the socket metrics from netlink.
 func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
-	// First pass: only track listeners bound to 0.0.0.0 (inbound), keyed by port.
 	listeners := make(map[uint16]*listenerMetrics)
 
 	listenObjs, err := c.getSocketStats(unix.BPF_TCP_LISTEN)
@@ -123,20 +207,13 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 		if ipAddr.String() != "0.0.0.0" {
 			continue
 		}
-
 		port := diag.Ntohs(object.ID.SPort)
 		if _, exists := listeners[port]; exists {
 			continue
 		}
-		listeners[port] = &listenerMetrics{
-			address: "0.0.0.0",
-			port:    port,
-			active:  0,
-			queued:  0,
-		}
+		listeners[port] = &listenerMetrics{address: "0.0.0.0", port: port}
 	}
 
-	// Second pass: match established connections to listeners by port
 	establishedObjs, err := c.getSocketStats(unix.BPF_TCP_ESTABLISHED)
 	if err != nil {
 		return nil, fmt.Errorf("could not dump stats for established sockets: %w", err)
@@ -148,7 +225,6 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 		if metrics == nil {
 			continue
 		}
-
 		if object.INode == 0 {
 			metrics.queued++
 		} else {
@@ -163,8 +239,12 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 	return result, nil
 }
 
-// Close closes the netlink connection.
+// Close stops the background sampling goroutine and closes the netlink connection.
 func (c *Collector) Close() error {
+	if c.done != nil {
+		close(c.done)
+		c.wg.Wait()
+	}
 	if c.netlink != nil {
 		return c.netlink.Close()
 	}

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -95,6 +95,9 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 	for i := range c.buckets {
 		c.buckets[i] = make(map[string]listenerHWM)
 	}
+	if err := c.sample(); err != nil {
+		log.Printf("TCP connection sampling error: %v", err)
+	}
 	c.wg.Add(1)
 	go c.run()
 	return c, nil
@@ -103,9 +106,6 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 // run is the background goroutine that samples netlink and rotates buckets.
 func (c *Collector) run() {
 	defer c.wg.Done()
-	if err := c.sample(); err != nil {
-		log.Printf("TCP connection sampling error: %v", err)
-	}
 	sampleTicker := time.NewTicker(c.interval)
 	rotateTicker := time.NewTicker(c.window / 2)
 	defer sampleTicker.Stop()

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -14,6 +14,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var (
+	activeDesc = prometheus.NewDesc(
+		"tcp_active_connections_peak",
+		"Peak number of active TCP connections in the configured high-water mark window.",
+		[]string{"listener", "window"}, nil,
+	)
+	queuedDesc = prometheus.NewDesc(
+		"tcp_queued_connections_peak",
+		"Peak number of queued TCP connections in the configured high-water mark window.",
+		[]string{"listener", "window"}, nil,
+	)
+)
+
 // NetlinkDumper is an interface for dumping netlink socket information.
 type NetlinkDumper interface {
 	NetDump(opt *diag.NetOption) ([]diag.NetObject, error)
@@ -40,12 +53,10 @@ type listenerMetrics struct {
 // previous and a fresh current starts. Collect returns max(current, previous),
 // making it safe for multiple Prometheus instances scraping at different times.
 type Collector struct {
-	netlink    NetlinkDumper
-	interval   time.Duration
-	window     time.Duration
-	activeDesc *prometheus.Desc
-	queuedDesc *prometheus.Desc
-	mu         sync.Mutex
+	netlink  NetlinkDumper
+	interval time.Duration
+	window   time.Duration
+	mu       sync.Mutex
 	current    map[string]listenerHWM
 	previous   map[string]listenerHWM
 	done       chan struct{}
@@ -72,16 +83,6 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 		netlink:  nl,
 		interval: interval,
 		window:   window,
-		activeDesc: prometheus.NewDesc(
-			"tcp_active_connections_peak",
-			fmt.Sprintf("Peak number of active TCP connections in the last %s", window),
-			[]string{"listener"}, nil,
-		),
-		queuedDesc: prometheus.NewDesc(
-			"tcp_queued_connections_peak",
-			fmt.Sprintf("Peak number of queued TCP connections in the last %s", window),
-			[]string{"listener"}, nil,
-		),
 		current:  make(map[string]listenerHWM),
 		previous: make(map[string]listenerHWM),
 		done:     make(chan struct{}),
@@ -174,8 +175,8 @@ func (c *Collector) rotate() {
 
 // Describe implements prometheus.Collector.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	ch <- c.activeDesc
-	ch <- c.queuedDesc
+	ch <- activeDesc
+	ch <- queuedDesc
 }
 
 // Collect implements prometheus.Collector. It returns max(current, previous)
@@ -199,18 +200,19 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	}
 	c.mu.Unlock()
 
+	window := c.window.String()
 	for listener, hwm := range merged {
 		ch <- prometheus.MustNewConstMetric(
-			c.activeDesc,
+			activeDesc,
 			prometheus.GaugeValue,
 			float64(hwm.active),
-			listener,
+			listener, window,
 		)
 		ch <- prometheus.MustNewConstMetric(
-			c.queuedDesc,
+			queuedDesc,
 			prometheus.GaugeValue,
 			float64(hwm.queued),
-			listener,
+			listener, window,
 		)
 	}
 }

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -50,6 +50,7 @@ type Collector struct {
 	previous   map[string]listenerHWM
 	done       chan struct{}
 	wg         sync.WaitGroup
+	closeOnce  sync.Once
 }
 
 // NewCollector creates a new Collector and starts the background sampling loop.
@@ -276,13 +277,17 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 }
 
 // Close stops the background sampling goroutine and closes the netlink connection.
+// It is safe to call multiple times; subsequent calls are no-ops.
 func (c *Collector) Close() error {
-	if c.done != nil {
-		close(c.done)
-		c.wg.Wait()
-	}
-	if c.netlink != nil {
-		return c.netlink.Close()
-	}
-	return nil
+	var err error
+	c.closeOnce.Do(func() {
+		if c.done != nil {
+			close(c.done)
+			c.wg.Wait()
+		}
+		if c.netlink != nil {
+			err = c.netlink.Close()
+		}
+	})
+	return err
 }

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -39,7 +39,6 @@ type connectionCounts struct {
 	queued int
 }
 
-
 // numBuckets is the number of ring-buffer buckets. Three buckets rotating at
 // window/2 guarantee a full window of lookback at any scrape time: the oldest
 // bucket covers [now-window, now-window/2], the middle [now-window/2, now],
@@ -268,6 +267,7 @@ func (c *Collector) collectMetrics() (map[string]connectionCounts, error) {
 			continue
 		}
 		hwm := listeners[key]
+		// If the inode is zero, the connection is queued.
 		if object.INode == 0 {
 			hwm.queued++
 		} else {
@@ -284,13 +284,9 @@ func (c *Collector) collectMetrics() (map[string]connectionCounts, error) {
 func (c *Collector) Close() error {
 	var err error
 	c.closeOnce.Do(func() {
-		if c.done != nil {
-			close(c.done)
-			c.wg.Wait()
-		}
-		if c.netlink != nil {
-			err = c.netlink.Close()
-		}
+		close(c.done)
+		c.wg.Wait()
+		err = c.netlink.Close()
 	})
 	return err
 }

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -93,6 +93,7 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 // run is the background goroutine that samples netlink and rotates buckets.
 func (c *Collector) run() {
 	defer c.wg.Done()
+	c.sample()
 	sampleTicker := time.NewTicker(c.interval)
 	rotateTicker := time.NewTicker(c.window / 2)
 	defer sampleTicker.Stop()

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -57,6 +57,12 @@ type Collector struct {
 // Prometheus scrape interval; buckets rotate at window/2 internally so that
 // any scrape always covers at least one full rotation period.
 func NewCollector(interval, window time.Duration) (*Collector, error) {
+	if interval <= 0 {
+		return nil, fmt.Errorf("sampling interval must be positive, got %s", interval)
+	}
+	if window <= 0 {
+		return nil, fmt.Errorf("HWM window must be positive, got %s", window)
+	}
 	nl, err := diag.Open(&diag.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("could not open netlink socket: %w", err)

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -47,21 +47,28 @@ type listenerMetrics struct {
 	queued  int
 }
 
-// Collector collects TCP connection metrics using a two-bucket high-water mark.
+// numBuckets is the number of ring-buffer buckets. Three buckets rotating at
+// window/2 guarantee a full window of lookback at any scrape time: the oldest
+// bucket covers [now-window, now-window/2], the middle [now-window/2, now],
+// and the current is accumulating. Collect returns max across all three.
+const numBuckets = 3
+
+// Collector collects TCP connection metrics using a ring-buffer high-water mark.
 // A background goroutine samples netlink every interval and advances the current
-// bucket upward. Every window/2 duration the bucket rotates: current becomes
-// previous and a fresh current starts. Collect returns max(current, previous),
-// making it safe for multiple Prometheus instances scraping at different times.
+// bucket upward. Every window/2 duration the ring advances: the oldest bucket is
+// cleared and becomes the new current. Collect returns the max across all buckets,
+// guaranteeing a full window of lookback regardless of when the scrape falls
+// relative to a rotation boundary, and consistent values for HA Prometheus setups.
 type Collector struct {
-	netlink  NetlinkDumper
-	interval time.Duration
-	window   time.Duration
-	mu       sync.Mutex
-	current    map[string]listenerHWM
-	previous   map[string]listenerHWM
-	done       chan struct{}
-	wg         sync.WaitGroup
-	closeOnce  sync.Once
+	netlink   NetlinkDumper
+	interval  time.Duration
+	window    time.Duration
+	mu        sync.Mutex
+	buckets   [numBuckets]map[string]listenerHWM
+	head      int // index of the current (most recent) bucket
+	done      chan struct{}
+	wg        sync.WaitGroup
+	closeOnce sync.Once
 }
 
 // NewCollector creates a new Collector and starts the background sampling loop.
@@ -83,9 +90,10 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 		netlink:  nl,
 		interval: interval,
 		window:   window,
-		current:  make(map[string]listenerHWM),
-		previous: make(map[string]listenerHWM),
 		done:     make(chan struct{}),
+	}
+	for i := range c.buckets {
+		c.buckets[i] = make(map[string]listenerHWM)
 	}
 	c.wg.Add(1)
 	go c.run()
@@ -151,26 +159,27 @@ func (c *Collector) sample() error {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	current := c.buckets[c.head]
 	for _, m := range metrics {
 		key := fmt.Sprintf("%s:%d", m.address, m.port)
-		hwm := c.current[key]
+		hwm := current[key]
 		if m.active > hwm.active {
 			hwm.active = m.active
 		}
 		if m.queued > hwm.queued {
 			hwm.queued = m.queued
 		}
-		c.current[key] = hwm
+		current[key] = hwm
 	}
 	return nil
 }
 
-// rotate moves the current bucket to previous and starts a fresh current bucket.
+// rotate advances the ring: the next slot is cleared and becomes the new current.
 func (c *Collector) rotate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.previous = c.current
-	c.current = make(map[string]listenerHWM)
+	c.head = (c.head + 1) % numBuckets
+	c.buckets[c.head] = make(map[string]listenerHWM)
 }
 
 // Describe implements prometheus.Collector.
@@ -179,24 +188,23 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- queuedDesc
 }
 
-// Collect implements prometheus.Collector. It returns max(current, previous)
+// Collect implements prometheus.Collector. It returns the max across all buckets
 // for each listener and does not reset state, so multiple scrapers see
 // consistent values.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.Lock()
-	merged := make(map[string]listenerHWM, len(c.current)+len(c.previous))
-	for k, v := range c.previous {
-		merged[k] = v
-	}
-	for k, v := range c.current {
-		prev := merged[k]
-		if v.active > prev.active {
-			prev.active = v.active
+	merged := make(map[string]listenerHWM)
+	for _, bucket := range c.buckets {
+		for k, v := range bucket {
+			m := merged[k]
+			if v.active > m.active {
+				m.active = v.active
+			}
+			if v.queued > m.queued {
+				m.queued = v.queued
+			}
+			merged[k] = m
 		}
-		if v.queued > prev.queued {
-			prev.queued = v.queued
-		}
-		merged[k] = prev
 	}
 	c.mu.Unlock()
 

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -39,24 +39,24 @@ type connectionCounts struct {
 	queued int
 }
 
-// numBuckets is the number of ring-buffer buckets. Three buckets rotating at
-// window/2 guarantee a full window of lookback at any scrape time: the oldest
-// bucket covers [now-window, now-window/2], the middle [now-window/2, now],
-// and the current is accumulating. Collect returns max across all three.
-const numBuckets = 3
+// rotationInterval is how often the ring buffer advances to a fresh bucket.
+// Rotating every second means the reported peak can only be stale by at most 1s
+// regardless of the configured window size.
+const rotationInterval = time.Second
 
 // Collector collects TCP connection metrics using a ring-buffer high-water mark.
 // A background goroutine samples netlink every interval and advances the current
-// bucket upward. Every window/2 duration the ring advances: the oldest bucket is
-// cleared and becomes the new current. Collect returns the max across all buckets,
-// guaranteeing a full window of lookback regardless of when the scrape falls
-// relative to a rotation boundary, and consistent values for HA Prometheus setups.
+// bucket upward. Every second the ring advances: the oldest bucket is cleared and
+// becomes the new current. The ring holds window/rotationInterval + 1 buckets so
+// that Collect always returns a max spanning a full window, regardless of when the
+// scrape falls relative to a rotation boundary. Consistent values for HA Prometheus
+// setups are guaranteed because state is never reset on scrape.
 type Collector struct {
 	netlink   NetlinkDumper
 	interval  time.Duration
 	window    time.Duration
 	mu        sync.Mutex
-	buckets   [numBuckets]map[string]connectionCounts
+	buckets   []map[string]connectionCounts
 	head      int // index of the current (most recent) bucket
 	done      chan struct{}
 	wg        sync.WaitGroup
@@ -65,23 +65,25 @@ type Collector struct {
 
 // NewCollector creates a new Collector and starts the background sampling loop.
 // interval controls how often netlink is polled. window should match your
-// Prometheus scrape interval; buckets rotate at window/2 internally so that
-// any scrape always covers at least one full rotation period.
+// Prometheus scrape interval; the ring rotates every second so the reported
+// peak is never more than 1s stale.
 func NewCollector(interval, window time.Duration) (*Collector, error) {
 	if interval <= 0 {
 		return nil, fmt.Errorf("sampling interval must be positive, got %s", interval)
 	}
-	if window/2 <= 0 {
-		return nil, fmt.Errorf("HWM window must be at least 2ns, got %s", window)
+	if window < rotationInterval {
+		return nil, fmt.Errorf("HWM window must be at least %s, got %s", rotationInterval, window)
 	}
 	nl, err := diag.Open(&diag.Config{})
 	if err != nil {
 		return nil, fmt.Errorf("could not open netlink socket: %w", err)
 	}
+	numBuckets := int(window/rotationInterval) + 1
 	c := &Collector{
 		netlink:  nl,
 		interval: interval,
 		window:   window,
+		buckets:  make([]map[string]connectionCounts, numBuckets),
 		done:     make(chan struct{}),
 	}
 	for i := range c.buckets {
@@ -99,7 +101,7 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 func (c *Collector) run() {
 	defer c.wg.Done()
 	sampleTicker := time.NewTicker(c.interval)
-	rotateTicker := time.NewTicker(c.window / 2)
+	rotateTicker := time.NewTicker(rotationInterval)
 	defer sampleTicker.Stop()
 	defer rotateTicker.Stop()
 	var backoff time.Duration
@@ -167,7 +169,7 @@ func (c *Collector) sample() error {
 func (c *Collector) rotate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.head = (c.head + 1) % numBuckets
+	c.head = (c.head + 1) % len(c.buckets)
 	c.buckets[c.head] = make(map[string]connectionCounts)
 }
 

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -60,8 +60,8 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 	if interval <= 0 {
 		return nil, fmt.Errorf("sampling interval must be positive, got %s", interval)
 	}
-	if window <= 0 {
-		return nil, fmt.Errorf("HWM window must be positive, got %s", window)
+	if window/2 <= 0 {
+		return nil, fmt.Errorf("HWM window must be at least 2ns, got %s", window)
 	}
 	nl, err := diag.Open(&diag.Config{})
 	if err != nil {

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -112,6 +112,8 @@ func (c *Collector) run() {
 				log.Printf("TCP connection sampling error (retrying in %s): %v", backoff, err)
 				select {
 				case <-time.After(backoff):
+				case <-rotateTicker.C:
+					c.rotate()
 				case <-c.done:
 					return
 				}

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -33,19 +33,12 @@ type NetlinkDumper interface {
 	Close() error
 }
 
-// listenerHWM holds the high-water mark active and queued connection counts for a listener.
-type listenerHWM struct {
+// connectionCounts holds the active and queued connection counts for a listener.
+type connectionCounts struct {
 	active int
 	queued int
 }
 
-// listenerMetrics holds the active and queued request counts sampled from netlink.
-type listenerMetrics struct {
-	address string
-	port    uint16
-	active  int
-	queued  int
-}
 
 // numBuckets is the number of ring-buffer buckets. Three buckets rotating at
 // window/2 guarantee a full window of lookback at any scrape time: the oldest
@@ -64,7 +57,7 @@ type Collector struct {
 	interval  time.Duration
 	window    time.Duration
 	mu        sync.Mutex
-	buckets   [numBuckets]map[string]listenerHWM
+	buckets   [numBuckets]map[string]connectionCounts
 	head      int // index of the current (most recent) bucket
 	done      chan struct{}
 	wg        sync.WaitGroup
@@ -93,7 +86,7 @@ func NewCollector(interval, window time.Duration) (*Collector, error) {
 		done:     make(chan struct{}),
 	}
 	for i := range c.buckets {
-		c.buckets[i] = make(map[string]listenerHWM)
+		c.buckets[i] = make(map[string]connectionCounts)
 	}
 	if err := c.sample(); err != nil {
 		log.Printf("TCP connection sampling error: %v", err)
@@ -158,8 +151,7 @@ func (c *Collector) sample() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	current := c.buckets[c.head]
-	for _, m := range metrics {
-		key := fmt.Sprintf("%s:%d", m.address, m.port)
+	for key, m := range metrics {
 		hwm := current[key]
 		if m.active > hwm.active {
 			hwm.active = m.active
@@ -177,7 +169,7 @@ func (c *Collector) rotate() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.head = (c.head + 1) % numBuckets
-	c.buckets[c.head] = make(map[string]listenerHWM)
+	c.buckets[c.head] = make(map[string]connectionCounts)
 }
 
 // Describe implements prometheus.Collector.
@@ -191,7 +183,7 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 // consistent values.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.mu.Lock()
-	merged := make(map[string]listenerHWM)
+	merged := make(map[string]connectionCounts)
 	for _, bucket := range c.buckets {
 		for k, v := range bucket {
 			m := merged[k]
@@ -238,14 +230,16 @@ func (c *Collector) getSocketStats(state uint8) ([]diag.NetObject, error) {
 }
 
 // collectMetrics collects the socket metrics from netlink.
-func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
-	listeners := make(map[uint16]*listenerMetrics)
-
+func (c *Collector) collectMetrics() (map[string]connectionCounts, error) {
 	listenObjs, err := c.getSocketStats(unix.BPF_TCP_LISTEN)
 	if err != nil {
 		return nil, fmt.Errorf("could not dump stats for listening sockets: %w", err)
 	}
 
+	// Build the set of wildcard listeners keyed by "address:port".
+	// Use a port→key map to efficiently match established connections below.
+	portKey := make(map[uint16]string)
+	listeners := make(map[string]connectionCounts)
 	for _, object := range listenObjs {
 		ipAddr, err := diag.ToNetipAddrWithFamily(unix.AF_INET, object.ID.Src)
 		if err != nil {
@@ -255,10 +249,12 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 			continue
 		}
 		port := diag.Ntohs(object.ID.SPort)
-		if _, exists := listeners[port]; exists {
+		if _, exists := portKey[port]; exists {
 			continue
 		}
-		listeners[port] = &listenerMetrics{address: "0.0.0.0", port: port}
+		key := fmt.Sprintf("0.0.0.0:%d", port)
+		portKey[port] = key
+		listeners[key] = connectionCounts{}
 	}
 
 	establishedObjs, err := c.getSocketStats(unix.BPF_TCP_ESTABLISHED)
@@ -267,23 +263,20 @@ func (c *Collector) collectMetrics() ([]listenerMetrics, error) {
 	}
 
 	for _, object := range establishedObjs {
-		sPort := diag.Ntohs(object.ID.SPort)
-		metrics := listeners[sPort]
-		if metrics == nil {
+		key, ok := portKey[diag.Ntohs(object.ID.SPort)]
+		if !ok {
 			continue
 		}
+		hwm := listeners[key]
 		if object.INode == 0 {
-			metrics.queued++
+			hwm.queued++
 		} else {
-			metrics.active++
+			hwm.active++
 		}
+		listeners[key] = hwm
 	}
 
-	result := make([]listenerMetrics, 0, len(listeners))
-	for _, m := range listeners {
-		result = append(result, *m)
-	}
-	return result, nil
+	return listeners, nil
 }
 
 // Close stops the background sampling goroutine and closes the netlink connection.

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -136,7 +136,7 @@ func nextBackoff(current time.Duration) time.Duration {
 	if current == 0 {
 		return initial
 	}
-	if next := current * 2; next < max {
+	if next := current * 2; next <= max {
 		return next
 	}
 	return max

--- a/exporter/tcpconnections/collector.go
+++ b/exporter/tcpconnections/collector.go
@@ -111,21 +111,19 @@ func (c *Collector) run() {
 	defer sampleTicker.Stop()
 	defer rotateTicker.Stop()
 	var backoff time.Duration
+	var retryAfter time.Time
 	for {
 		select {
 		case <-c.done:
 			return
 		case <-sampleTicker.C:
+			if time.Now().Before(retryAfter) {
+				continue
+			}
 			if err := c.sample(); err != nil {
 				backoff = nextBackoff(backoff)
+				retryAfter = time.Now().Add(backoff)
 				log.Printf("TCP connection sampling error (retrying in %s): %v", backoff, err)
-				select {
-				case <-time.After(backoff):
-				case <-rotateTicker.C:
-					c.rotate()
-				case <-c.done:
-					return
-				}
 			} else if backoff > 0 {
 				log.Println("TCP connection sampling recovered")
 				backoff = 0

--- a/exporter/tcpconnections/collector_stub.go
+++ b/exporter/tcpconnections/collector_stub.go
@@ -4,30 +4,25 @@
 package tcpconnections
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Collector collects metrics about requests in progress and queuing for a Ruby application server.
-// On non-Linux platforms, this is a stub that does nothing.
+// Collector is a no-op stub for non-Linux platforms.
 type Collector struct{}
 
-// NewCollector creates a new Collector. On non-Linux platforms, this returns a stub collector.
-func NewCollector() (*Collector, error) {
+// NewCollector returns a stub collector. The interval and window parameters
+// are accepted to match the Linux implementation but are ignored.
+func NewCollector(interval, window time.Duration) (*Collector, error) {
 	return &Collector{}, nil
 }
 
-// Describe implements prometheus.Collector. On non-Linux platforms, this does nothing.
-func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	// Stub: no-op on non-Linux platforms
-}
+// Describe implements prometheus.Collector.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {}
 
-// Collect implements prometheus.Collector. On non-Linux platforms, this does nothing.
-func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	// Stub: no-op on non-Linux platforms
-}
+// Collect implements prometheus.Collector.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {}
 
-// Close closes the collector. On non-Linux platforms, this does nothing.
-func (c *Collector) Close() error {
-	// Stub: no-op on non-Linux platforms
-	return nil
-}
+// Close implements io.Closer.
+func (c *Collector) Close() error { return nil }

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -4,14 +4,49 @@
 package tcpconnections
 
 import (
+	"fmt"
 	"net/netip"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/florianl/go-diag"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/sys/unix"
 )
+
+// newTestCollector builds a Collector with a mock netlink dumper and
+// pre-initialised buckets, but without starting the background goroutine.
+// Tests drive sampling and rotation directly via sample() and rotate().
+const testWindow = 30 * time.Second
+
+func newTestCollector(mock *mockNetlinkDumper) *Collector {
+	return &Collector{
+		netlink: mock,
+		activeDesc: prometheus.NewDesc(
+			"tcp_active_connections_peak",
+			fmt.Sprintf("Peak number of active TCP connections in the last %s", testWindow),
+			[]string{"listener"}, nil,
+		),
+		queuedDesc: prometheus.NewDesc(
+			"tcp_queued_connections_peak",
+			fmt.Sprintf("Peak number of queued TCP connections in the last %s", testWindow),
+			[]string{"listener"}, nil,
+		),
+		current:  make(map[string]listenerHWM),
+		previous: make(map[string]listenerHWM),
+	}
+}
+
+// makeActive returns n active (non-zero inode) established connections on port.
+func makeActive(port uint16, n int) []diag.NetObject {
+	objs := make([]diag.NetObject, n)
+	for i := range objs {
+		objs[i] = makeNetObject("172.19.0.1", port, unix.BPF_TCP_ESTABLISHED, uint32(i+1))
+	}
+	return objs
+}
 
 func TestCollector_Collect(t *testing.T) {
 	tests := []struct {
@@ -26,12 +61,12 @@ func TestCollector_Collect(t *testing.T) {
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 `,
 		},
 		{
@@ -40,17 +75,16 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			establishedObjects: []diag.NetObject{
-				// Established connections have client IPs, but same port (matched by port)
 				makeNetObject("172.19.0.2", 3000, unix.BPF_TCP_ESTABLISHED, 12345),
 				makeNetObject("172.19.0.3", 3000, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 2
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 2
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 `,
 		},
 		{
@@ -59,17 +93,16 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			establishedObjects: []diag.NetObject{
-				// Queued connections have client IPs, but same port (matched by port)
 				makeNetObject("172.19.0.2", 3000, unix.BPF_TCP_ESTABLISHED, 0),
 				makeNetObject("172.19.0.3", 3000, unix.BPF_TCP_ESTABLISHED, 0),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 2
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 2
 `,
 		},
 		{
@@ -78,18 +111,17 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 2
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			establishedObjects: []diag.NetObject{
-				// Mixed connections with different client IPs, matched by port
 				makeNetObject("172.19.0.2", 3000, unix.BPF_TCP_ESTABLISHED, 12345),
 				makeNetObject("172.19.0.3", 3000, unix.BPF_TCP_ESTABLISHED, 0),
 				makeNetObject("172.19.0.4", 3000, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 2
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 1
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 2
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 1
 `,
 		},
 		{
@@ -103,14 +135,14 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 1
 				makeNetObject("127.0.0.1", 8080, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 1
-tcp_active_connections{listener="0.0.0.0:8080"} 1
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
-tcp_queued_connections{listener="0.0.0.0:8080"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 1
+tcp_active_connections_peak{listener="0.0.0.0:8080"} 1
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:8080"} 0
 `,
 		},
 		{
@@ -120,12 +152,12 @@ tcp_queued_connections{listener="0.0.0.0:8080"} 0
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 `,
 		},
 		{
@@ -134,22 +166,20 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			establishedObjects: []diag.NetObject{
-				// Connection on different port, should be ignored
 				makeNetObject("172.19.0.2", 9999, unix.BPF_TCP_ESTABLISHED, 12345),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 `,
 		},
 		{
 			name: "duplicate listeners from netlink are deduplicated",
 			listenObjects: []diag.NetObject{
-				// Same listener reported multiple times (as seen in some environments)
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
@@ -158,12 +188,12 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 				makeNetObject("172.19.0.2", 3000, unix.BPF_TCP_ESTABLISHED, 12345),
 			},
 			expected: `
-# HELP tcp_active_connections Number of active connections
-# TYPE tcp_active_connections gauge
-tcp_active_connections{listener="0.0.0.0:3000"} 1
-# HELP tcp_queued_connections Number of connections in queue
-# TYPE tcp_queued_connections gauge
-tcp_queued_connections{listener="0.0.0.0:3000"} 0
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 1
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 `,
 		},
 	}
@@ -174,7 +204,8 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 				listenObjects:      tt.listenObjects,
 				establishedObjects: tt.establishedObjects,
 			}
-			collector := &Collector{netlink: mock}
+			collector := newTestCollector(mock)
+			collector.sample()
 
 			if err := testutil.CollectAndCompare(collector, strings.NewReader(tt.expected)); err != nil {
 				t.Errorf("CollectAndCompare failed: %v", err)
@@ -184,7 +215,6 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 			if err != nil {
 				t.Errorf("CollectAndLint failed: %v", err)
 			}
-
 			if len(problems) > 0 {
 				t.Errorf("CollectAndLint found %d problems:", len(problems))
 				for _, problem := range problems {
@@ -195,12 +225,134 @@ tcp_queued_connections{listener="0.0.0.0:3000"} 0
 	}
 }
 
-func TestCollector_Close(t *testing.T) {
-	mock := &mockNetlinkDumper{
-		closeError: nil,
-	}
-	collector := &Collector{netlink: mock}
+func TestCollector_HWM(t *testing.T) {
+	listener := []diag.NetObject{makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0)}
 
+	t.Run("peak is reported across multiple samples", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener}
+		c := newTestCollector(mock)
+
+		mock.establishedObjects = makeActive(3000, 5)
+		c.sample()
+		mock.establishedObjects = makeActive(3000, 3) // lower
+		c.sample()
+		mock.establishedObjects = makeActive(3000, 8) // new peak
+		c.sample()
+		mock.establishedObjects = makeActive(3000, 2) // lower again
+		c.sample()
+
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 8
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+	})
+
+	t.Run("Collect is idempotent — no reset on scrape", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
+		c := newTestCollector(mock)
+		c.sample()
+
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 5
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("first scrape failed: %v", err)
+		}
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("second scrape returned different values: %v", err)
+		}
+	})
+
+	t.Run("peak persists across rotation into previous bucket", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
+		c := newTestCollector(mock)
+		c.sample()  // current: active=10
+		c.rotate()  // previous: active=10, current: empty
+
+		// No new samples yet — should still see the peak via previous
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 10
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+	})
+
+	t.Run("peak clears after two rotations with no activity", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
+		c := newTestCollector(mock)
+		c.sample()  // current: active=10
+		c.rotate()  // previous: active=10, current: empty
+
+		mock.establishedObjects = nil
+		c.sample()  // current: active=0 (listener present, no connections)
+		c.rotate()  // previous: active=0, current: empty
+
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+	})
+
+	t.Run("disappeared listener still reported via previous bucket", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
+		c := newTestCollector(mock)
+		c.sample()  // current: active=5
+		c.rotate()  // previous: active=5, current: empty
+
+		// Listener disappears
+		mock.listenObjects = nil
+		mock.establishedObjects = nil
+		c.sample()  // current: empty (no listeners in netlink)
+
+		// Peak still visible via previous bucket
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000"} 5
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+
+		// After a second rotation the listener is fully gone
+		c.rotate()
+		if err := testutil.CollectAndCompare(c, strings.NewReader("")); err != nil {
+			t.Errorf("expected no metrics after second rotation: %v", err)
+		}
+	})
+}
+
+func TestCollector_Close(t *testing.T) {
+	mock := &mockNetlinkDumper{}
+	collector := newTestCollector(mock)
 	if err := collector.Close(); err != nil {
 		t.Errorf("Close() error = %v, want nil", err)
 	}
@@ -214,7 +366,6 @@ type mockNetlinkDumper struct {
 }
 
 func (m *mockNetlinkDumper) NetDump(opt *diag.NetOption) ([]diag.NetObject, error) {
-	// Determine which state was requested
 	if opt.State&(1<<unix.BPF_TCP_LISTEN) != 0 {
 		return m.listenObjects, nil
 	}
@@ -228,25 +379,23 @@ func (m *mockNetlinkDumper) Close() error {
 	return m.closeError
 }
 
-// Helper function to create a SockID with the given IP and port
+// makeSockID builds a diag.SockID from a dotted-decimal IP and port.
 func makeSockID(ipStr string, port uint16) diag.SockID {
 	ip := netip.MustParseAddr(ipStr)
 	ipBytes := ip.As4()
 
-	// Convert IP bytes to uint32 in network byte order (big-endian)
-	// The IP address is stored in the first uint32
+	// Convert IP bytes to uint32 in network byte order (big-endian).
+	// The IP address is stored in the first uint32.
 	ipUint32 := uint32(ipBytes[3])<<24 | uint32(ipBytes[2])<<16 | uint32(ipBytes[1])<<8 | uint32(ipBytes[0])
 
 	var src [4]uint32
-	src[0] = ipUint32 // IP address in first uint32
-	// Remaining uint32s are zero
+	src[0] = ipUint32 // IP address in first uint32; remaining uint32s are zero
 
-	// Port needs to be in network byte order (big-endian)
-	// diag.Ntohs converts FROM network byte order TO host byte order
-	// So we store it in network byte order (big-endian)
-	// On a little-endian system, this means swapping the bytes
-	// Port 3000 = 0x0BB8, in network byte order = 0xB80B (bytes swapped)
-	portNet := uint16((port&0xFF)<<8 | (port>>8)&0xFF) // Swap bytes
+	// Port needs to be in network byte order (big-endian).
+	// diag.Ntohs converts FROM network byte order TO host byte order,
+	// so we store it in network byte order by swapping the bytes.
+	// e.g. port 3000 = 0x0BB8 becomes 0xB80B in network byte order.
+	portNet := uint16((port&0xFF)<<8 | (port>>8)&0xFF) // swap bytes
 
 	return diag.SockID{
 		Src:   src,
@@ -254,7 +403,7 @@ func makeSockID(ipStr string, port uint16) diag.SockID {
 	}
 }
 
-// Helper function to create a NetObject
+// makeNetObject creates a NetObject with the given IP, port, state, and inode.
 func makeNetObject(ipStr string, port uint16, state uint8, inode uint32) diag.NetObject {
 	return diag.NetObject{
 		DiagMsg: diag.DiagMsg{

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -23,6 +23,7 @@ func newTestCollector(mock *mockNetlinkDumper) *Collector {
 	c := &Collector{
 		netlink: mock,
 		window:  testWindow,
+		done:    make(chan struct{}),
 	}
 	for i := range c.buckets {
 		c.buckets[i] = make(map[string]connectionCounts)

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -4,6 +4,7 @@
 package tcpconnections
 
 import (
+	"fmt"
 	"net/netip"
 	"strings"
 	"testing"
@@ -366,6 +367,61 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 	})
 }
 
+func TestCollector_SampleError(t *testing.T) {
+	listener := []diag.NetObject{makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0)}
+
+	t.Run("error leaves bucket unchanged", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
+		c := newTestCollector(mock)
+		requireSample(t, c) // bucket: active=5
+
+		mock.dumpError = fmt.Errorf("netlink unavailable")
+		if err := c.sample(); err == nil {
+			t.Fatal("expected error from sample(), got nil")
+		}
+
+		// Bucket should still reflect the last successful sample
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+	})
+
+	t.Run("recovery after error resumes updating bucket", func(t *testing.T) {
+		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 3)}
+		c := newTestCollector(mock)
+		requireSample(t, c) // bucket: active=3
+
+		mock.dumpError = fmt.Errorf("netlink unavailable")
+		if err := c.sample(); err == nil {
+			t.Fatal("expected error from sample(), got nil")
+		}
+
+		mock.dumpError = nil
+		mock.establishedObjects = makeActive(3000, 7)
+		requireSample(t, c) // bucket: active=7 (new peak)
+
+		expected := `
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
+# TYPE tcp_active_connections_peak gauge
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 7
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
+# TYPE tcp_queued_connections_peak gauge
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+`
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("CollectAndCompare failed: %v", err)
+		}
+	})
+}
+
 func TestNextBackoff(t *testing.T) {
 	tests := []struct {
 		current  time.Duration
@@ -399,10 +455,14 @@ func TestCollector_Close(t *testing.T) {
 type mockNetlinkDumper struct {
 	listenObjects      []diag.NetObject
 	establishedObjects []diag.NetObject
+	dumpError          error
 	closeError         error
 }
 
 func (m *mockNetlinkDumper) NetDump(opt *diag.NetOption) ([]diag.NetObject, error) {
+	if m.dumpError != nil {
+		return nil, m.dumpError
+	}
 	if opt.State&(1<<unix.BPF_TCP_LISTEN) != 0 {
 		return m.listenObjects, nil
 	}

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -15,15 +15,19 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const testWindow = 30 * time.Second
+// testWindow is small so that tests need few rotations to exercise expiry.
+// With rotationInterval=1s this gives int(3s/1s)+1 = 4 buckets.
+const testWindow = 3 * time.Second
 
 // newTestCollector builds a Collector with a mock netlink dumper and
 // pre-initialised buckets, but without starting the background goroutine.
 // Tests drive sampling and rotation directly via sample() and rotate().
 func newTestCollector(mock *mockNetlinkDumper) *Collector {
+	numBuckets := int(testWindow/rotationInterval) + 1
 	c := &Collector{
 		netlink: mock,
 		window:  testWindow,
+		buckets: make([]map[string]connectionCounts, numBuckets),
 		done:    make(chan struct{}),
 	}
 	for i := range c.buckets {
@@ -64,10 +68,10 @@ func TestCollector_Collect(t *testing.T) {
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `,
 		},
 		{
@@ -82,10 +86,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 2
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `,
 		},
 		{
@@ -100,10 +104,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 2
 `,
 		},
 		{
@@ -119,10 +123,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 2
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 1
 `,
 		},
 		{
@@ -138,12 +142,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
-tcp_active_connections_peak{listener="0.0.0.0:8080",window="30s"} 1
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 1
+tcp_active_connections_peak{listener="0.0.0.0:8080",window="3s"} 1
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
-tcp_queued_connections_peak{listener="0.0.0.0:8080",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:8080",window="3s"} 0
 `,
 		},
 		{
@@ -155,10 +159,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:8080",window="30s"} 0
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `,
 		},
 		{
@@ -172,10 +176,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `,
 		},
 		{
@@ -191,10 +195,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 			expected: `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 1
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `,
 		},
 	}
@@ -245,10 +249,10 @@ func TestCollector_HWM(t *testing.T) {
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 8
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 8
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
@@ -263,10 +267,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 5
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("first scrape failed: %v", err)
@@ -280,56 +284,51 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
 		requireSample(t, c) // bucket[0]: active=10
-		c.rotate()          // head→bucket[1] (empty); bucket[0] still holds active=10
 
-		// No new samples yet — peak still visible in older bucket
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 10
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 10
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
-		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
-			t.Errorf("CollectAndCompare failed: %v", err)
-		}
-
-		// Second rotation: peak is now in the oldest bucket, still visible (full window guarantee)
-		c.rotate()
-		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
-			t.Errorf("peak should still be visible after second rotation: %v", err)
+		// Peak should survive numBuckets-1 rotations (full window guarantee)
+		for i := 1; i < len(c.buckets); i++ {
+			c.rotate()
+			if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+				t.Errorf("peak should still be visible after rotation %d: %v", i, err)
+			}
 		}
 	})
 
-	t.Run("peak clears after three rotations with no activity", func(t *testing.T) {
+	t.Run("peak clears after numBuckets rotations with no activity", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
 		requireSample(t, c) // bucket[0]: active=10
-		c.rotate()          // head→bucket[1] (empty)
-
+		// Rotate through all remaining buckets with zero activity,
+		// then one more rotation overwrites bucket[0], clearing the peak.
 		mock.establishedObjects = nil
-		requireSample(t, c) // bucket[1]: active=0 (listener present, no connections)
-		c.rotate()          // head→bucket[2] (empty); bucket[0] active=10 still in ring
-
-		// Peak still visible in oldest bucket
-		requireSample(t, c) // bucket[2]: active=0
-		c.rotate()          // head→bucket[0], cleared; all buckets now active=0
+		for i := 1; i < len(c.buckets); i++ {
+			c.rotate()
+			requireSample(t, c) // bucket[i]: active=0
+		}
+		c.rotate() // head wraps back to bucket[0], which is cleared
 
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
 		}
 	})
 
-	t.Run("disappeared listener still reported via older buckets", func(t *testing.T) {
+	t.Run("disappeared listener still reported until ring fully cycles", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
 		c := newTestCollector(mock)
 		requireSample(t, c) // bucket[0]: active=5
@@ -340,29 +339,26 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		mock.establishedObjects = nil
 		requireSample(t, c) // bucket[1]: empty (no listeners in netlink)
 
-		// Peak still visible in older bucket
+		// Peak still visible while bucket[0] remains in the ring
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 5
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
-		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
-			t.Errorf("CollectAndCompare failed: %v", err)
+		for i := 2; i < len(c.buckets); i++ {
+			c.rotate()
+			if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+				t.Errorf("expected peak still visible after rotation %d: %v", i, err)
+			}
 		}
 
-		// Second rotation: peak now in oldest bucket, still visible
-		c.rotate()
-		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
-			t.Errorf("expected peak still visible after second rotation: %v", err)
-		}
-
-		// Third rotation: oldest bucket is cleared, listener fully gone
+		// One final rotation overwrites bucket[0]; listener fully gone
 		c.rotate()
 		if err := testutil.CollectAndCompare(c, strings.NewReader("")); err != nil {
-			t.Errorf("expected no metrics after third rotation: %v", err)
+			t.Errorf("expected no metrics after ring fully cycled: %v", err)
 		}
 	})
 }
@@ -384,10 +380,10 @@ func TestCollector_SampleError(t *testing.T) {
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 5
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
@@ -411,10 +407,10 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 7
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="3s"} 7
 # HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="3s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -366,6 +366,27 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 	})
 }
 
+func TestNextBackoff(t *testing.T) {
+	tests := []struct {
+		current  time.Duration
+		expected time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1 * time.Second, 2 * time.Second},
+		{2 * time.Second, 4 * time.Second},
+		{4 * time.Second, 8 * time.Second},
+		{8 * time.Second, 16 * time.Second},
+		{16 * time.Second, 32 * time.Second},
+		{32 * time.Second, 60 * time.Second},
+		{60 * time.Second, 60 * time.Second}, // capped at max
+	}
+	for _, tt := range tests {
+		if got := nextBackoff(tt.current); got != tt.expected {
+			t.Errorf("nextBackoff(%s) = %s, want %s", tt.current, got, tt.expected)
+		}
+	}
+}
+
 func TestCollector_Close(t *testing.T) {
 	mock := &mockNetlinkDumper{}
 	collector := newTestCollector(mock)

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -4,36 +4,25 @@
 package tcpconnections
 
 import (
-	"fmt"
 	"net/netip"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/florianl/go-diag"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/sys/unix"
 )
 
+const testWindow = 30 * time.Second
+
 // newTestCollector builds a Collector with a mock netlink dumper and
 // pre-initialised buckets, but without starting the background goroutine.
 // Tests drive sampling and rotation directly via sample() and rotate().
-const testWindow = 30 * time.Second
-
 func newTestCollector(mock *mockNetlinkDumper) *Collector {
 	return &Collector{
-		netlink: mock,
-		activeDesc: prometheus.NewDesc(
-			"tcp_active_connections_peak",
-			fmt.Sprintf("Peak number of active TCP connections in the last %s", testWindow),
-			[]string{"listener"}, nil,
-		),
-		queuedDesc: prometheus.NewDesc(
-			"tcp_queued_connections_peak",
-			fmt.Sprintf("Peak number of queued TCP connections in the last %s", testWindow),
-			[]string{"listener"}, nil,
-		),
+		netlink:  mock,
+		window:   testWindow,
 		current:  make(map[string]listenerHWM),
 		previous: make(map[string]listenerHWM),
 	}
@@ -69,12 +58,12 @@ func TestCollector_Collect(t *testing.T) {
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `,
 		},
 		{
@@ -87,12 +76,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 				makeNetObject("172.19.0.3", 3000, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 2
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `,
 		},
 		{
@@ -105,12 +94,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 				makeNetObject("172.19.0.3", 3000, unix.BPF_TCP_ESTABLISHED, 0),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 2
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
 `,
 		},
 		{
@@ -124,12 +113,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 2
 				makeNetObject("172.19.0.4", 3000, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 2
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 2
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 1
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
 `,
 		},
 		{
@@ -143,14 +132,14 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 1
 				makeNetObject("127.0.0.1", 8080, unix.BPF_TCP_ESTABLISHED, 12346),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 1
-tcp_active_connections_peak{listener="0.0.0.0:8080"} 1
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
+tcp_active_connections_peak{listener="0.0.0.0:8080",window="30s"} 1
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
-tcp_queued_connections_peak{listener="0.0.0.0:8080"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:8080",window="30s"} 0
 `,
 		},
 		{
@@ -160,12 +149,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:8080"} 0
 				makeNetObject("0.0.0.0", 3000, unix.BPF_TCP_LISTEN, 0),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `,
 		},
 		{
@@ -177,12 +166,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 				makeNetObject("172.19.0.2", 9999, unix.BPF_TCP_ESTABLISHED, 12345),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `,
 		},
 		{
@@ -196,12 +185,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 				makeNetObject("172.19.0.2", 3000, unix.BPF_TCP_ESTABLISHED, 12345),
 			},
 			expected: `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 1
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 1
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `,
 		},
 	}
@@ -250,12 +239,12 @@ func TestCollector_HWM(t *testing.T) {
 		requireSample(t, c)
 
 		expected := `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 8
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 8
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
@@ -268,12 +257,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 		requireSample(t, c)
 
 		expected := `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 5
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("first scrape failed: %v", err)
@@ -291,12 +280,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 
 		// No new samples yet — should still see the peak via previous
 		expected := `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 10
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 10
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
@@ -314,12 +303,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 		c.rotate()  // previous: active=0, current: empty
 
 		expected := `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 0
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
@@ -339,12 +328,12 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 
 		// Peak still visible via previous bucket
 		expected := `
-# HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
+# HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
-tcp_active_connections_peak{listener="0.0.0.0:3000"} 5
-# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the last 30s
+tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"} 5
+# HELP tcp_queued_connections_peak Peak number of queued TCP connections in the configured high-water mark window.
 # TYPE tcp_queued_connections_peak gauge
-tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
+tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 `
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -20,12 +20,14 @@ const testWindow = 30 * time.Second
 // pre-initialised buckets, but without starting the background goroutine.
 // Tests drive sampling and rotation directly via sample() and rotate().
 func newTestCollector(mock *mockNetlinkDumper) *Collector {
-	return &Collector{
-		netlink:  mock,
-		window:   testWindow,
-		current:  make(map[string]listenerHWM),
-		previous: make(map[string]listenerHWM),
+	c := &Collector{
+		netlink: mock,
+		window:  testWindow,
 	}
+	for i := range c.buckets {
+		c.buckets[i] = make(map[string]listenerHWM)
+	}
+	return c
 }
 
 // makeActive returns n active (non-zero inode) established connections on port.
@@ -272,13 +274,13 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		}
 	})
 
-	t.Run("peak persists across rotation into previous bucket", func(t *testing.T) {
+	t.Run("peak persists across rotation into older buckets", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
-		requireSample(t, c)  // current: active=10
-		c.rotate()  // previous: active=10, current: empty
+		requireSample(t, c) // bucket[0]: active=10
+		c.rotate()          // head→bucket[1] (empty); bucket[0] still holds active=10
 
-		// No new samples yet — should still see the peak via previous
+		// No new samples yet — peak still visible in older bucket
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
@@ -290,17 +292,27 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
 			t.Errorf("CollectAndCompare failed: %v", err)
 		}
+
+		// Second rotation: peak is now in the oldest bucket, still visible (full window guarantee)
+		c.rotate()
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("peak should still be visible after second rotation: %v", err)
+		}
 	})
 
-	t.Run("peak clears after two rotations with no activity", func(t *testing.T) {
+	t.Run("peak clears after three rotations with no activity", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
-		requireSample(t, c)  // current: active=10
-		c.rotate()  // previous: active=10, current: empty
+		requireSample(t, c) // bucket[0]: active=10
+		c.rotate()          // head→bucket[1] (empty)
 
 		mock.establishedObjects = nil
-		requireSample(t, c)  // current: active=0 (listener present, no connections)
-		c.rotate()  // previous: active=0, current: empty
+		requireSample(t, c) // bucket[1]: active=0 (listener present, no connections)
+		c.rotate()          // head→bucket[2] (empty); bucket[0] active=10 still in ring
+
+		// Peak still visible in oldest bucket
+		requireSample(t, c) // bucket[2]: active=0
+		c.rotate()          // head→bucket[0], cleared; all buckets now active=0
 
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
@@ -315,18 +327,18 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 		}
 	})
 
-	t.Run("disappeared listener still reported via previous bucket", func(t *testing.T) {
+	t.Run("disappeared listener still reported via older buckets", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
 		c := newTestCollector(mock)
-		requireSample(t, c)  // current: active=5
-		c.rotate()  // previous: active=5, current: empty
+		requireSample(t, c) // bucket[0]: active=5
+		c.rotate()          // head→bucket[1] (empty)
 
 		// Listener disappears
 		mock.listenObjects = nil
 		mock.establishedObjects = nil
-		requireSample(t, c)  // current: empty (no listeners in netlink)
+		requireSample(t, c) // bucket[1]: empty (no listeners in netlink)
 
-		// Peak still visible via previous bucket
+		// Peak still visible in older bucket
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the configured high-water mark window.
 # TYPE tcp_active_connections_peak gauge
@@ -339,10 +351,16 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"} 0
 			t.Errorf("CollectAndCompare failed: %v", err)
 		}
 
-		// After a second rotation the listener is fully gone
+		// Second rotation: peak now in oldest bucket, still visible
+		c.rotate()
+		if err := testutil.CollectAndCompare(c, strings.NewReader(expected)); err != nil {
+			t.Errorf("expected peak still visible after second rotation: %v", err)
+		}
+
+		// Third rotation: oldest bucket is cleared, listener fully gone
 		c.rotate()
 		if err := testutil.CollectAndCompare(c, strings.NewReader("")); err != nil {
-			t.Errorf("expected no metrics after second rotation: %v", err)
+			t.Errorf("expected no metrics after third rotation: %v", err)
 		}
 	})
 }

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -48,6 +48,14 @@ func makeActive(port uint16, n int) []diag.NetObject {
 	return objs
 }
 
+// requireSample calls c.sample() and fails the test immediately if it errors.
+func requireSample(t *testing.T, c *Collector) {
+	t.Helper()
+	if err := c.sample(); err != nil {
+		t.Fatalf("unexpected sample error: %v", err)
+	}
+}
+
 func TestCollector_Collect(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -205,7 +213,7 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 				establishedObjects: tt.establishedObjects,
 			}
 			collector := newTestCollector(mock)
-			collector.sample()
+			requireSample(t, collector)
 
 			if err := testutil.CollectAndCompare(collector, strings.NewReader(tt.expected)); err != nil {
 				t.Errorf("CollectAndCompare failed: %v", err)
@@ -233,13 +241,13 @@ func TestCollector_HWM(t *testing.T) {
 		c := newTestCollector(mock)
 
 		mock.establishedObjects = makeActive(3000, 5)
-		c.sample()
+		requireSample(t, c)
 		mock.establishedObjects = makeActive(3000, 3) // lower
-		c.sample()
+		requireSample(t, c)
 		mock.establishedObjects = makeActive(3000, 8) // new peak
-		c.sample()
+		requireSample(t, c)
 		mock.establishedObjects = makeActive(3000, 2) // lower again
-		c.sample()
+		requireSample(t, c)
 
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
@@ -257,7 +265,7 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 	t.Run("Collect is idempotent — no reset on scrape", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
 		c := newTestCollector(mock)
-		c.sample()
+		requireSample(t, c)
 
 		expected := `
 # HELP tcp_active_connections_peak Peak number of active TCP connections in the last 30s
@@ -278,7 +286,7 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 	t.Run("peak persists across rotation into previous bucket", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
-		c.sample()  // current: active=10
+		requireSample(t, c)  // current: active=10
 		c.rotate()  // previous: active=10, current: empty
 
 		// No new samples yet — should still see the peak via previous
@@ -298,11 +306,11 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 	t.Run("peak clears after two rotations with no activity", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 10)}
 		c := newTestCollector(mock)
-		c.sample()  // current: active=10
+		requireSample(t, c)  // current: active=10
 		c.rotate()  // previous: active=10, current: empty
 
 		mock.establishedObjects = nil
-		c.sample()  // current: active=0 (listener present, no connections)
+		requireSample(t, c)  // current: active=0 (listener present, no connections)
 		c.rotate()  // previous: active=0, current: empty
 
 		expected := `
@@ -321,13 +329,13 @@ tcp_queued_connections_peak{listener="0.0.0.0:3000"} 0
 	t.Run("disappeared listener still reported via previous bucket", func(t *testing.T) {
 		mock := &mockNetlinkDumper{listenObjects: listener, establishedObjects: makeActive(3000, 5)}
 		c := newTestCollector(mock)
-		c.sample()  // current: active=5
+		requireSample(t, c)  // current: active=5
 		c.rotate()  // previous: active=5, current: empty
 
 		// Listener disappears
 		mock.listenObjects = nil
 		mock.establishedObjects = nil
-		c.sample()  // current: empty (no listeners in netlink)
+		requireSample(t, c)  // current: empty (no listeners in netlink)
 
 		// Peak still visible via previous bucket
 		expected := `

--- a/exporter/tcpconnections/collector_test.go
+++ b/exporter/tcpconnections/collector_test.go
@@ -25,7 +25,7 @@ func newTestCollector(mock *mockNetlinkDumper) *Collector {
 		window:  testWindow,
 	}
 	for i := range c.buckets {
-		c.buckets[i] = make(map[string]listenerHWM)
+		c.buckets[i] = make(map[string]connectionCounts)
 	}
 	return c
 }

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe "promenade" do
     expect(get("http://localhost:9394/metrics").code).to eq("200")
 
     # Check we have connection metrics for pitchfork and nginx listeners
-    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:3000"}')).not_to be_nil
-    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292"}')).not_to be_nil
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:3000",window="30s"}')).not_to be_nil
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292",window="30s"}')).not_to be_nil
 
-    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:3000"}')).not_to be_nil
-    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292"}')).not_to be_nil
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:3000",window="30s"}')).not_to be_nil
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292",window="30s"}')).not_to be_nil
 
     # Make a request so initial value of all metrics is written
     get("http://localhost:3000/example")
@@ -33,7 +33,7 @@ RSpec.describe "promenade" do
     # Wait for all the requests to start
     sleep 0.5
 
-    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292"}')).to eq(4)
-    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292"}').to_i).to be >= 6
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292",window="30s"}')).to eq(4)
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292",window="30s"}').to_i).to be >= 6
   end
 end

--- a/spec/acceptance/acceptance_spec.rb
+++ b/spec/acceptance/acceptance_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe "promenade" do
     expect(get("http://localhost:9394/metrics").code).to eq("200")
 
     # Check we have connection metrics for pitchfork and nginx listeners
-    expect(get_metric_value('tcp_active_connections{listener="0.0.0.0:3000"}')).to eq(0)
-    expect(get_metric_value('tcp_active_connections{listener="0.0.0.0:9292"}')).to eq(0)
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:3000"}')).not_to be_nil
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292"}')).not_to be_nil
 
-    expect(get_metric_value('tcp_queued_connections{listener="0.0.0.0:3000"}')).to eq(0)
-    expect(get_metric_value('tcp_queued_connections{listener="0.0.0.0:9292"}')).to eq(0)
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:3000"}')).not_to be_nil
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292"}')).not_to be_nil
 
-    # Make a reuqest so initial value of all metrics is written
+    # Make a request so initial value of all metrics is written
     get("http://localhost:3000/example")
 
     expect(get_metric_value("pitchfork_workers")).to eq(4)
@@ -33,7 +33,7 @@ RSpec.describe "promenade" do
     # Wait for all the requests to start
     sleep 0.5
 
-    expect(get_metric_value('tcp_active_connections{listener="0.0.0.0:9292"}')).to eq(4)
-    expect(get_metric_value('tcp_queued_connections{listener="0.0.0.0:9292"}').to_i).to be >= 6
+    expect(get_metric_value('tcp_active_connections_peak{listener="0.0.0.0:9292"}')).to eq(4)
+    expect(get_metric_value('tcp_queued_connections_peak{listener="0.0.0.0:9292"}').to_i).to be >= 6
   end
 end


### PR DESCRIPTION
Sampling these metrics each scrape means that we only get a snapshot of
the behaviour of the server, and don't know what is happening between
each scrape.

Sampling more often (every 25ms) means that we capture the peak
load on the server between each scrape.